### PR TITLE
fix: stabilise tool URL navigation

### DIFF
--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -1,7 +1,7 @@
 import type { RouterConfig } from '@nuxt/schema'
 
 function findHashPosition(hash: string): { el: string, behavior: ScrollBehavior, top: number } | undefined {
-  const el = document.querySelector(hash)
+  const el = document.getElementById(hash.slice(1))
   // vue-router does not incorporate scroll-margin-top on its own.
   if (el) {
     const top = Number.parseFloat(getComputedStyle(el).scrollMarginTop)
@@ -15,7 +15,7 @@ function findHashPosition(hash: string): { el: string, behavior: ScrollBehavior,
 }
 
 // https://router.vuejs.org/api/#routeroptions
-export default <RouterConfig>{
+export default {
   scrollBehavior(to, from, savedPosition) {
     const nuxtApp = useNuxtApp()
 
@@ -46,4 +46,4 @@ export default <RouterConfig>{
     // Scroll to top of window
     return { top: 0 }
   },
-}
+} as RouterConfig

--- a/layers/tools/app/composables/useToolUrlSync.ts
+++ b/layers/tools/app/composables/useToolUrlSync.ts
@@ -1,4 +1,5 @@
-import { useUrlSearchParams, watchDebounced } from '@vueuse/core'
+import { watchDebounced } from '@vueuse/core'
+import { readToolQueryValue, replaceToolQuery } from '../utils/tool-url'
 
 interface ToolUrlSyncOptions {
   /** Query param name for the URL input (default: 'url') */
@@ -13,13 +14,20 @@ interface ToolUrlSyncOptions {
 
 export function useToolUrlSync(urlInput: Ref<string>, options: ToolUrlSyncOptions = {}) {
   const { paramName = 'url', extraParams, onReady, debounce = 500 } = options
-  const params = useUrlSearchParams<Record<string, string | undefined>>('history')
+  const route = useRoute()
+  const router = useRouter()
+
+  function syncQueryParam(paramKey: string, value: string, defaultValue?: string) {
+    void replaceToolQuery(router, paramKey, value, defaultValue).catch((error) => {
+      console.error('[tool-url] Failed to sync query parameter', error)
+    })
+  }
 
   onMounted(() => {
-    const urlParam = params[paramName]
+    const urlParam = readToolQueryValue(route.query[paramName])
     if (extraParams) {
       for (const [queryKey, ref] of Object.entries(extraParams)) {
-        const val = params[queryKey]
+        const val = readToolQueryValue(route.query[queryKey])
         if (val)
           ref.value = val
       }
@@ -33,7 +41,7 @@ export function useToolUrlSync(urlInput: Ref<string>, options: ToolUrlSyncOption
   watchDebounced(
     urlInput,
     (newUrl) => {
-      params[paramName] = newUrl || undefined
+      syncQueryParam(paramName, newUrl)
     },
     { debounce },
   )
@@ -41,7 +49,7 @@ export function useToolUrlSync(urlInput: Ref<string>, options: ToolUrlSyncOption
   /** Sync a single query param reactively */
   function syncParam(paramKey: string, value: Ref<string>, defaultValue?: string) {
     watch(value, (newVal) => {
-      params[paramKey] = defaultValue && newVal === defaultValue ? undefined : newVal
+      syncQueryParam(paramKey, newVal, defaultValue)
     })
   }
 

--- a/layers/tools/app/utils/tool-url.ts
+++ b/layers/tools/app/utils/tool-url.ts
@@ -1,0 +1,31 @@
+export type ToolQueryValue = string | string[] | null | undefined
+export type ToolQuery = Record<string, ToolQueryValue>
+
+export interface ToolQueryRouter {
+  currentRoute: {
+    value: {
+      query: Readonly<ToolQuery>
+    }
+  }
+  replace: (location: { query: ToolQuery }) => Promise<unknown>
+}
+
+export function replaceToolQuery(
+  router: ToolQueryRouter,
+  paramKey: string,
+  value: string,
+  defaultValue?: string,
+): Promise<unknown> {
+  const query: ToolQuery = { ...router.currentRoute.value.query }
+
+  if (!value || value === defaultValue)
+    delete query[paramKey]
+  else
+    query[paramKey] = value
+
+  return router.replace({ query })
+}
+
+export function readToolQueryValue(value: ToolQueryValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value ?? undefined
+}

--- a/tests/router-scroll.test.ts
+++ b/tests/router-scroll.test.ts
@@ -1,0 +1,39 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import routerOptions from '../app/router.options.ts'
+
+test('ignores URL-state fragments that are not element ids', async () => {
+  const originalDocument = globalThis.document
+  const originalSetTimeout = globalThis.setTimeout
+  const originalUseNuxtApp = (globalThis as any).useNuxtApp
+
+  ;(globalThis as any).document = {
+    getElementById() {
+      return null
+    },
+    querySelector(selector: string) {
+      throw new SyntaxError(`${selector} is not a valid selector`)
+    },
+  }
+  ;(globalThis as any).useNuxtApp = () => ({ hooks: { hookOnce() {} } })
+  ;(globalThis as any).setTimeout = (callback: (...args: any[]) => void, _delay: number, ...args: any[]) => {
+    callback(...args)
+    return 0
+  }
+
+  try {
+    const position = await routerOptions.scrollBehavior?.(
+      { path: '/tools/lighthouse-score-calculator', hash: '#device=mobile&FCP=3015' } as any,
+      { path: '/tools/lighthouse-score-calculator' } as any,
+      null,
+    )
+
+    assert.equal(position, undefined)
+  }
+  finally {
+    globalThis.document = originalDocument
+    globalThis.setTimeout = originalSetTimeout
+    ;(globalThis as any).useNuxtApp = originalUseNuxtApp
+  }
+})

--- a/tests/sentry-filter.test.ts
+++ b/tests/sentry-filter.test.ts
@@ -1,0 +1,35 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { filterKnownClientNoise } from '../shared/sentry.ts'
+
+const manifestFetchFailure = {
+  exception: {
+    values: [{
+      type: 'TypeError',
+      value: 'Failed to fetch',
+      stacktrace: { frames: [] },
+      mechanism: {
+        type: 'auto.browser.global_handlers.onunhandledrejection',
+        handled: false,
+      },
+    }],
+  },
+  breadcrumbs: [
+    { category: 'fetch', data: { url: '/_nuxt/builds/meta/build-id.json' } },
+    { category: 'console', message: '[NUXT_E5002]' },
+  ],
+}
+
+test('drops a stackless Nuxt manifest fetch failure', () => {
+  assert.equal(filterKnownClientNoise(manifestFetchFailure), null)
+})
+
+test('keeps other stackless fetch failures', () => {
+  const apiFetchFailure = {
+    ...manifestFetchFailure,
+    breadcrumbs: [{ category: 'fetch', data: { url: '/api/stats.json' } }],
+  }
+
+  assert.equal(filterKnownClientNoise(apiFetchFailure), apiFetchFailure)
+})

--- a/tests/tool-url.test.ts
+++ b/tests/tool-url.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { replaceToolQuery } from '../layers/tools/app/utils/tool-url.ts'
+
+test('replaces tool query through the router without pre-encoding values', async () => {
+  const locations: unknown[] = []
+  const router = {
+    currentRoute: {
+      value: {
+        query: { strategy: 'desktop' },
+      },
+    },
+    replace(location: unknown) {
+      locations.push(location)
+      return Promise.resolve()
+    },
+  }
+
+  await replaceToolQuery(router, 'url', 'bulkpartner.net/type/penthouse/')
+
+  assert.deepEqual(locations, [{
+    query: {
+      strategy: 'desktop',
+      url: 'bulkpartner.net/type/penthouse/',
+    },
+  }])
+})
+
+test('removes empty and default tool query values', async () => {
+  const locations: unknown[] = []
+  const router = {
+    currentRoute: {
+      value: {
+        query: { strategy: 'desktop', url: 'example.com' },
+      },
+    },
+    replace(location: unknown) {
+      locations.push(location)
+      return Promise.resolve()
+    },
+  }
+
+  await replaceToolQuery(router, 'url', '')
+  router.currentRoute.value.query = { strategy: 'desktop', url: 'example.com' }
+  await replaceToolQuery(router, 'strategy', 'mobile', 'mobile')
+
+  assert.deepEqual(locations, [
+    { query: { strategy: 'desktop' } },
+    { query: { url: 'example.com' } },
+  ])
+})


### PR DESCRIPTION
### 🔗 Linked issue

Sentry incidents UNLIGHTHOUSE-7, UNLIGHTHOUSE-5, and UNLIGHTHOUSE-6.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Safely resolves fragment targets by element ID, so URL state cannot become an invalid CSS selector.

Routes tool query changes through Vue Router, so route state and browser history stay consistent.

Adds behavior tests for both fixes. It also verifies the existing Nuxt manifest failure filter.