### PR TITLE
fix(tools): keep the PageSpeed API key out of error messages

### DIFF
--- a/layers/tools/server/utils/crux.ts
+++ b/layers/tools/server/utils/crux.ts
@@ -1,4 +1,6 @@
 import type { H3Event } from 'h3'
+import type { CruxEndpoint } from '~~/shared/crux-request'
+import { buildCruxRequestUrl, describeCruxFailure, readUpstreamStatus } from '~~/shared/crux-request'
 
 export type FormFactor = 'PHONE' | 'DESKTOP' | 'TABLET' | 'ALL_FORM_FACTORS'
 
@@ -181,8 +183,10 @@ export async function fetchCrUXHistory(event: H3Event, url: string, mode: 'origi
   if (!apiKey)
     throw createError({ statusCode: 500, message: 'Google API key not configured' })
 
-  const endpoint = `https://chromeuxreport.googleapis.com/v1/records:queryHistoryRecord?key=${apiKey}`
+  return fetchCrux<CrUXHistoryResult>(event, 'history', apiKey, buildCruxPayload(url, mode, formFactor))
+}
 
+function buildCruxPayload(url: string, mode: 'origin' | 'url', formFactor: FormFactor): Record<string, unknown> {
   const payload: Record<string, unknown> = {}
   if (formFactor !== 'ALL_FORM_FACTORS')
     payload.formFactor = formFactor
@@ -196,15 +200,27 @@ export async function fetchCrUXHistory(event: H3Event, url: string, mode: 'origi
     payload.url = url
   }
 
-  return $fetch<{ record: CrUXHistoryResult }>(endpoint, {
+  return payload
+}
+
+async function fetchCrux<RecordType>(event: H3Event, endpoint: CruxEndpoint, apiKey: string, payload: Record<string, unknown>) {
+  return $fetch<{ record: RecordType }>(buildCruxRequestUrl(endpoint), {
     method: 'POST',
+    headers: { 'X-Goog-Api-Key': apiKey },
     body: payload,
-  }).catch((e) => {
-    const status = e?.status || e?.statusCode
+  }).catch((error) => {
+    // The 404 and 400 cases mean "no data for this URL", which is a normal outcome.
+    const status = readUpstreamStatus(error)
     if (status === 404 || status === 400)
       return null
-    const apiMessage = e?.data?.error?.message || e?.message || 'CrUX API error'
-    throw createError({ statusCode: status || 502, message: `CrUX API: ${apiMessage}` })
+
+    // ofetch puts the full request URL in its message, so never forward it.
+    const failure = describeCruxFailure(error)
+    throw createError({
+      statusCode: failure.statusCode,
+      statusMessage: failure.message,
+      message: failure.message,
+    })
   })
 }
 
@@ -284,28 +300,5 @@ export async function fetchCrUXCurrent(event: H3Event, url: string, mode: 'origi
   if (!apiKey)
     throw createError({ statusCode: 500, message: 'Google API key not configured' })
 
-  const endpoint = `https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=${apiKey}`
-
-  const payload: Record<string, unknown> = {}
-  if (formFactor !== 'ALL_FORM_FACTORS')
-    payload.formFactor = formFactor
-
-  if (mode === 'origin') {
-    const parsed = new URL(url.startsWith('http') ? url : `https://${url}`)
-    payload.origin = `${parsed.protocol}//${parsed.host}`
-  }
-  else {
-    payload.url = url
-  }
-
-  return $fetch<{ record: CrUXCurrentResult }>(endpoint, {
-    method: 'POST',
-    body: payload,
-  }).catch((e) => {
-    const status = e?.status || e?.statusCode
-    if (status === 404 || status === 400)
-      return null
-    const apiMessage = e?.data?.error?.message || e?.message || 'CrUX API error'
-    throw createError({ statusCode: status || 502, message: `CrUX API: ${apiMessage}` })
-  })
+  return fetchCrux<CrUXCurrentResult>(event, 'current', apiKey, buildCruxPayload(url, mode, formFactor))
 }

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nuxt'
-import { createSentryDataCollection, filterKnownClientNoise, SENTRY_DSN } from './shared/sentry'
+import { createSentryDataCollection, filterKnownClientNoise, redactSentrySecrets, SENTRY_DSN } from './shared/sentry'
 
 if (!import.meta.dev) {
   Sentry.init({
@@ -7,7 +7,7 @@ if (!import.meta.dev) {
     environment: 'production',
     tracesSampleRate: 0.05,
     dataCollection: createSentryDataCollection(),
-    beforeSend: filterKnownClientNoise,
+    beforeSend: event => redactSentrySecrets(filterKnownClientNoise(event)),
     denyUrls: [/^iabjs:\/\//i],
     ignoreErrors: [
       /Failed to fetch dynamically imported module/i,

--- a/server/plugins/sentry.ts
+++ b/server/plugins/sentry.ts
@@ -1,5 +1,5 @@
 import { sentryCloudflareNitroPlugin } from '@sentry/nuxt/module/plugins'
-import { createSentryDataCollection } from '../../shared/sentry'
+import { createSentryDataCollection, redactSentrySecrets } from '../../shared/sentry'
 
 export default defineNitroPlugin((nitroApp) => {
   const { sentry } = useRuntimeConfig()
@@ -12,5 +12,6 @@ export default defineNitroPlugin((nitroApp) => {
     release: sentry.release || undefined,
     tracesSampleRate: sentry.tracesSampleRate,
     dataCollection: createSentryDataCollection(),
+    beforeSend: redactSentrySecrets,
   })(nitroApp)
 })

--- a/server/utils/psi.ts
+++ b/server/utils/psi.ts
@@ -1,14 +1,19 @@
 import type { H3Event } from 'h3'
+import { buildPsiRequestUrl, describePsiFailure } from '../../shared/psi-request'
 
 const _fetchPSI = cachedFunction(async (url: string, strategy: 'mobile' | 'desktop', token: string) => {
-  const psiUrl = new URL('https://www.googleapis.com/pagespeedonline/v5/runPagespeed')
-  psiUrl.searchParams.set('url', url)
-  psiUrl.searchParams.set('category', 'PERFORMANCE')
-  psiUrl.searchParams.set('strategy', strategy)
-  psiUrl.searchParams.set('key', token)
-
-  return $fetch<PSIResult>(psiUrl.toString(), {
+  return $fetch<PSIResult>(buildPsiRequestUrl(url, strategy), {
     timeout: 120_000, // 2 min - PSI can be slow
+    headers: { 'X-Goog-Api-Key': token },
+  }).catch((error) => {
+    // ofetch puts the full request URL in its message, so never forward it.
+    const failure = describePsiFailure(error)
+    throw createError({
+      statusCode: failure.statusCode,
+      statusMessage: failure.message,
+      message: failure.message,
+      data: { upstreamStatus: failure.upstreamStatus },
+    })
   })
 }, {
   base: 'psi',

--- a/shared/crux-request.ts
+++ b/shared/crux-request.ts
@@ -1,0 +1,61 @@
+export type CruxEndpoint = 'current' | 'history'
+
+const CRUX_ENDPOINTS = {
+  current: 'https://chromeuxreport.googleapis.com/v1/records:queryRecord',
+  history: 'https://chromeuxreport.googleapis.com/v1/records:queryHistoryRecord',
+} as const
+
+/**
+ * Build the Chrome UX Report request URL.
+ *
+ * The API key is deliberately absent. It travels in the `X-Goog-Api-Key` header instead, so a
+ * failed request cannot carry the key into an error message, a log line, or a Sentry issue title.
+ */
+export function buildCruxRequestUrl(endpoint: CruxEndpoint): string {
+  return CRUX_ENDPOINTS[endpoint]
+}
+
+export interface CruxFailure {
+  /** Status this site returns to the browser. */
+  statusCode: number
+  message: string
+}
+
+export function readUpstreamStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object')
+    return null
+
+  const candidate = error as { response?: { status?: unknown }, status?: unknown, statusCode?: unknown }
+  const status = candidate.response?.status ?? candidate.status ?? candidate.statusCode
+
+  return typeof status === 'number' && status >= 100 && status <= 599 ? status : null
+}
+
+/**
+ * Describe a failed Chrome UX Report call.
+ *
+ * The upstream message is never forwarded. Google echoes the whole request URL in its fetch errors,
+ * so forwarding it would leak the API key the same way the PageSpeed Insights errors did.
+ */
+export function describeCruxFailure(error: unknown): CruxFailure {
+  const upstreamStatus = readUpstreamStatus(error)
+
+  if (upstreamStatus === 429) {
+    return {
+      statusCode: 429,
+      message: 'Chrome UX Report is rate limited right now. Wait a minute, then try again.',
+    }
+  }
+
+  if (upstreamStatus !== null && upstreamStatus >= 400 && upstreamStatus < 500) {
+    return {
+      statusCode: 422,
+      message: 'Chrome UX Report could not look up this URL. Check that the page is public and that the API key is valid.',
+    }
+  }
+
+  return {
+    statusCode: upstreamStatus ?? 502,
+    message: 'Chrome UX Report did not return a result for this URL. This is a Google outage, not a problem with the page.',
+  }
+}

--- a/shared/psi-request.ts
+++ b/shared/psi-request.ts
@@ -1,0 +1,67 @@
+export type PsiStrategy = 'mobile' | 'desktop'
+
+const PSI_ENDPOINT = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed'
+
+/**
+ * Build the PageSpeed Insights request URL.
+ *
+ * The API key is deliberately absent. It travels in the `X-Goog-Api-Key` header instead, so a
+ * failed request cannot carry the key into an error message, a log line, or a Sentry issue title.
+ */
+export function buildPsiRequestUrl(url: string, strategy: PsiStrategy): string {
+  const psiUrl = new URL(PSI_ENDPOINT)
+  psiUrl.searchParams.set('url', url)
+  psiUrl.searchParams.set('category', 'PERFORMANCE')
+  psiUrl.searchParams.set('strategy', strategy)
+  return psiUrl.toString()
+}
+
+export interface PsiFailure {
+  /** Status this site returns to the browser. */
+  statusCode: number
+  /** Status Google returned, or null when the request never completed. */
+  upstreamStatus: number | null
+  message: string
+}
+
+function readUpstreamStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object')
+    return null
+
+  const candidate = error as { response?: { status?: unknown }, status?: unknown, statusCode?: unknown }
+  const status = candidate.response?.status ?? candidate.status ?? candidate.statusCode
+
+  return typeof status === 'number' && status >= 100 && status <= 599 ? status : null
+}
+
+/**
+ * Describe a failed PageSpeed Insights call.
+ *
+ * The upstream message is never forwarded. Google echoes the whole request URL in its fetch errors,
+ * so forwarding it is what leaked the API key into Sentry.
+ */
+export function describePsiFailure(error: unknown): PsiFailure {
+  const upstreamStatus = readUpstreamStatus(error)
+
+  if (upstreamStatus === 429) {
+    return {
+      statusCode: 429,
+      upstreamStatus,
+      message: 'PageSpeed Insights is rate limited right now. Wait a minute, then try again.',
+    }
+  }
+
+  if (upstreamStatus !== null && upstreamStatus >= 400 && upstreamStatus < 500) {
+    return {
+      statusCode: 422,
+      upstreamStatus,
+      message: 'PageSpeed Insights could not analyse this URL. Check that the page is public and loads without a redirect.',
+    }
+  }
+
+  return {
+    statusCode: 502,
+    upstreamStatus,
+    message: 'PageSpeed Insights did not return a result for this URL. This is a Google outage, not a problem with the page.',
+  }
+}

--- a/shared/sentry.ts
+++ b/shared/sentry.ts
@@ -42,6 +42,64 @@ export function filterKnownClientNoise<T extends SentryClientEvent>(event: T): T
     : event
 }
 
+const SECRET_QUERY_PARAM_RE = /\b(key|api_?key|access_token|auth_?token|token|password|secret|signature)=[^&"'\s]+/gi
+
+/** Replace credential query parameter values with a placeholder. */
+export function redactSecretsInText(text: string): string {
+  return text.replace(SECRET_QUERY_PARAM_RE, (_match, parameter: string) => `${parameter}=[REDACTED]`)
+}
+
+interface SentryRedactableEvent {
+  message?: string
+  exception?: {
+    values?: Array<{ value?: string }>
+  }
+  breadcrumbs?: Array<{
+    message?: string
+    data?: Record<string, unknown>
+  }>
+  request?: {
+    url?: string
+  }
+}
+
+function redactUnknown(value: unknown): unknown {
+  return typeof value === 'string' ? redactSecretsInText(value) : value
+}
+
+/**
+ * Strip credentials from every field of a Sentry event that carries free text.
+ *
+ * Defence in depth. Call sites should keep secrets out of error messages in the first place, but a
+ * leak here becomes a permanent issue title that cannot be edited.
+ */
+export function redactSentrySecrets<T extends SentryRedactableEvent>(event: T | null): T | null {
+  if (!event)
+    return event
+
+  if (typeof event.message === 'string')
+    event.message = redactSecretsInText(event.message)
+
+  for (const exception of event.exception?.values ?? []) {
+    if (typeof exception.value === 'string')
+      exception.value = redactSecretsInText(exception.value)
+  }
+
+  for (const breadcrumb of event.breadcrumbs ?? []) {
+    if (typeof breadcrumb.message === 'string')
+      breadcrumb.message = redactSecretsInText(breadcrumb.message)
+    if (breadcrumb.data) {
+      for (const [key, value] of Object.entries(breadcrumb.data))
+        breadcrumb.data[key] = redactUnknown(value)
+    }
+  }
+
+  if (typeof event.request?.url === 'string')
+    event.request.url = redactSecretsInText(event.request.url)
+
+  return event
+}
+
 export function sentryRelease(): string | undefined {
   return process.env.SENTRY_RELEASE || process.env.GITHUB_SHA || undefined
 }

--- a/tests/crux-request.test.ts
+++ b/tests/crux-request.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildCruxRequestUrl, describeCruxFailure } from '../shared/crux-request.ts'
+
+test('keeps the api key out of the crux request url', () => {
+  const url = buildCruxRequestUrl('current')
+
+  assert.equal(url, 'https://chromeuxreport.googleapis.com/v1/records:queryRecord')
+  assert.ok(!url.includes('key='))
+})
+
+test('keeps the api key out of the crux history request url', () => {
+  const url = buildCruxRequestUrl('history')
+
+  assert.equal(url, 'https://chromeuxreport.googleapis.com/v1/records:queryHistoryRecord')
+  assert.ok(!url.includes('key='))
+})
+
+test('maps an upstream 500 to the same status without the upstream message', () => {
+  const upstream = Object.assign(
+    new Error('[POST] "https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=AIzaSyLEAKED": 500 Internal Server Error'),
+    { response: { status: 500 } },
+  )
+
+  const failure = describeCruxFailure(upstream)
+
+  assert.equal(failure.statusCode, 500)
+  assert.ok(!failure.message.includes('AIzaSyLEAKED'))
+})
+
+test('maps upstream rate limiting to a rate limited response', () => {
+  const failure = describeCruxFailure(Object.assign(new Error('quota'), { status: 429 }))
+
+  assert.equal(failure.statusCode, 429)
+})
+
+test('maps a network failure with no status to a gateway failure', () => {
+  const failure = describeCruxFailure(new Error('fetch failed'))
+
+  assert.equal(failure.statusCode, 502)
+})
+
+test('maps a missing-data 404 to an unprocessable response when it escapes the no-data check', () => {
+  const failure = describeCruxFailure(Object.assign(new Error('no data'), { statusCode: 404 }))
+
+  assert.equal(failure.statusCode, 422)
+})

--- a/tests/psi-request.test.ts
+++ b/tests/psi-request.test.ts
@@ -1,0 +1,46 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildPsiRequestUrl, describePsiFailure } from '../shared/psi-request.ts'
+
+test('keeps the api key out of the request url', () => {
+  const url = new URL(buildPsiRequestUrl('https://corporate.walmart.com', 'mobile'))
+
+  assert.equal(url.searchParams.get('key'), null)
+  assert.equal(url.searchParams.get('url'), 'https://corporate.walmart.com')
+  assert.equal(url.searchParams.get('strategy'), 'mobile')
+  assert.equal(url.searchParams.get('category'), 'PERFORMANCE')
+})
+
+test('maps an upstream 500 to a gateway failure without the upstream message', () => {
+  const upstream = Object.assign(
+    new Error('[GET] "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=x&key=AIzaSyLEAKED": 500 Internal Server Error'),
+    { response: { status: 500 } },
+  )
+
+  const failure = describePsiFailure(upstream)
+
+  assert.equal(failure.statusCode, 502)
+  assert.equal(failure.upstreamStatus, 500)
+  assert.ok(!failure.message.includes('AIzaSyLEAKED'))
+})
+
+test('maps an upstream rejection of the target url to an unprocessable request', () => {
+  const failure = describePsiFailure(Object.assign(new Error('bad request'), { statusCode: 400 }))
+
+  assert.equal(failure.statusCode, 422)
+  assert.equal(failure.upstreamStatus, 400)
+})
+
+test('maps upstream rate limiting to a rate limited response', () => {
+  const failure = describePsiFailure(Object.assign(new Error('quota'), { status: 429 }))
+
+  assert.equal(failure.statusCode, 429)
+})
+
+test('maps a network failure with no status to a gateway failure', () => {
+  const failure = describePsiFailure(new Error('fetch failed'))
+
+  assert.equal(failure.statusCode, 502)
+  assert.equal(failure.upstreamStatus, null)
+})

--- a/tests/sentry-redaction.test.ts
+++ b/tests/sentry-redaction.test.ts
@@ -1,0 +1,40 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { redactSecretsInText, redactSentrySecrets } from '../shared/sentry.ts'
+
+test('redacts credential query parameters from free text', () => {
+  const text = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https%3A%2F%2Fexample.com&key=AIzaSyLEAKED123&strategy=mobile'
+
+  assert.equal(
+    redactSecretsInText(text),
+    'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https%3A%2F%2Fexample.com&key=[REDACTED]&strategy=mobile',
+  )
+})
+
+test('leaves text without credentials untouched', () => {
+  assert.equal(redactSecretsInText('monkey=banana'), 'monkey=banana')
+})
+
+test('redacts credentials from every place an event carries a message', () => {
+  const event = redactSentrySecrets({
+    message: 'failed with key=AIzaSyLEAKED123',
+    exception: {
+      values: [{ value: '[GET] "https://api.example.com/run?api_key=SECRET1": 500 Internal Server Error' }],
+    },
+    breadcrumbs: [
+      { message: 'called ?access_token=SECRET2', data: { url: 'https://api.example.com/run?key=SECRET3' } },
+    ],
+    request: { url: 'https://unlighthouse.dev/api/tools/x?token=SECRET4' },
+  })
+
+  const serialised = JSON.stringify(event)
+
+  assert.ok(!/SECRET\d/.test(serialised), serialised)
+  assert.ok(!serialised.includes('AIzaSyLEAKED123'), serialised)
+  assert.equal(event?.exception.values[0].value, '[GET] "https://api.example.com/run?api_key=[REDACTED]": 500 Internal Server Error')
+})
+
+test('passes a dropped event through unchanged', () => {
+  assert.equal(redactSentrySecrets(null), null)
+})


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Found this doing a Sentry check-in. `UNLIGHTHOUSE-8` is titled with our live Google API key:

```
Error: [GET] "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https%3A%2F%2Fcorporate.walmart.com&category=PERFORMANCE&strategy=mobile&key=AIzaSy…": 500 Internal Server Error
```

Google returns 500 for some targets, ofetch echoes the whole request URL in its message, and the key was a query parameter, so it went into the issue title and into whatever h3 handed back to the browser.

The key now travels in `X-Goog-Api-Key`, so the URL carries nothing secret. `describePsiFailure` maps the upstream status without forwarding its message: 4xx to 422, 429 to 429, anything else to 502, each with copy a person can act on rather than a raw Google dump. Both Sentry `beforeSend` hooks scrub credential query parameters too, since one leak becomes a permanent issue title nobody can edit.

Checked the header form against the live API before switching: header-only request returns 200, the same request with no auth returns 429.

Two loose ends. The key in that Sentry issue is still valid and wants rotating; I did not touch it. And I left the 502 case reporting to Sentry, on the theory that a sustained Google outage is worth knowing about, but it will be noisier than the 422 path.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).