### PR TITLE
fix(tools): keep expected Google outages out of Sentry

### DIFF
--- a/layers/tools/server/utils/crux.ts
+++ b/layers/tools/server/utils/crux.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
 import type { CruxEndpoint } from '~~/shared/crux-request'
-import { buildCruxRequestUrl, describeCruxFailure, readUpstreamStatus } from '~~/shared/crux-request'
+import { buildCruxRequestUrl, cruxFailureErrorOptions, readUpstreamStatus } from '~~/shared/crux-request'
 
 export type FormFactor = 'PHONE' | 'DESKTOP' | 'TABLET' | 'ALL_FORM_FACTORS'
 
@@ -215,12 +215,7 @@ async function fetchCrux<RecordType>(event: H3Event, endpoint: CruxEndpoint, api
       return null
 
     // ofetch puts the full request URL in its message, so never forward it.
-    const failure = describeCruxFailure(error)
-    throw createError({
-      statusCode: failure.statusCode,
-      statusMessage: failure.message,
-      message: failure.message,
-    })
+    throw createError(cruxFailureErrorOptions(error))
   })
 }
 

--- a/server/plugins/sentry.ts
+++ b/server/plugins/sentry.ts
@@ -1,5 +1,5 @@
 import { sentryCloudflareNitroPlugin } from '@sentry/nuxt/module/plugins'
-import { createSentryDataCollection, redactSentrySecrets } from '../../shared/sentry'
+import { createSentryDataCollection, filterExpectedUpstreamFailures, redactSentrySecrets } from '../../shared/sentry'
 
 export default defineNitroPlugin((nitroApp) => {
   const { sentry } = useRuntimeConfig()
@@ -12,6 +12,6 @@ export default defineNitroPlugin((nitroApp) => {
     release: sentry.release || undefined,
     tracesSampleRate: sentry.tracesSampleRate,
     dataCollection: createSentryDataCollection(),
-    beforeSend: redactSentrySecrets,
+    beforeSend: (event, hint) => redactSentrySecrets(filterExpectedUpstreamFailures(event, hint)),
   })(nitroApp)
 })

--- a/server/utils/psi.ts
+++ b/server/utils/psi.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import { buildPsiRequestUrl, describePsiFailure } from '../../shared/psi-request'
+import { buildPsiRequestUrl, psiFailureErrorOptions } from '../../shared/psi-request'
 
 const _fetchPSI = cachedFunction(async (url: string, strategy: 'mobile' | 'desktop', token: string) => {
   return $fetch<PSIResult>(buildPsiRequestUrl(url, strategy), {
@@ -7,13 +7,7 @@ const _fetchPSI = cachedFunction(async (url: string, strategy: 'mobile' | 'deskt
     headers: { 'X-Goog-Api-Key': token },
   }).catch((error) => {
     // ofetch puts the full request URL in its message, so never forward it.
-    const failure = describePsiFailure(error)
-    throw createError({
-      statusCode: failure.statusCode,
-      statusMessage: failure.message,
-      message: failure.message,
-      data: { upstreamStatus: failure.upstreamStatus },
-    })
+    throw createError(psiFailureErrorOptions(error))
   })
 }, {
   base: 'psi',

--- a/shared/crux-request.ts
+++ b/shared/crux-request.ts
@@ -1,3 +1,6 @@
+import type { UpstreamFailureErrorOptions } from './sentry.ts'
+import { EXPECTED_UPSTREAM_FAILURE } from './sentry.ts'
+
 export type CruxEndpoint = 'current' | 'history'
 
 const CRUX_ENDPOINTS = {
@@ -57,5 +60,25 @@ export function describeCruxFailure(error: unknown): CruxFailure {
   return {
     statusCode: upstreamStatus ?? 502,
     message: 'Chrome UX Report did not return a result for this URL. This is a Google outage, not a problem with the page.',
+  }
+}
+
+/**
+ * Build the `createError` input for a failed Chrome UX Report call.
+ *
+ * The marker in `data` is what keeps a Google outage out of Sentry. Raise every CrUX failure
+ * through here, never through a bare `createError`, or the outage returns as an issue.
+ */
+export function cruxFailureErrorOptions(error: unknown): UpstreamFailureErrorOptions {
+  const failure = describeCruxFailure(error)
+
+  return {
+    statusCode: failure.statusCode,
+    statusMessage: failure.message,
+    message: failure.message,
+    data: {
+      reason: EXPECTED_UPSTREAM_FAILURE,
+      upstreamStatus: readUpstreamStatus(error),
+    },
   }
 }

--- a/shared/psi-request.ts
+++ b/shared/psi-request.ts
@@ -1,3 +1,6 @@
+import type { UpstreamFailureErrorOptions } from './sentry.ts'
+import { EXPECTED_UPSTREAM_FAILURE } from './sentry.ts'
+
 export type PsiStrategy = 'mobile' | 'desktop'
 
 const PSI_ENDPOINT = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed'
@@ -63,5 +66,25 @@ export function describePsiFailure(error: unknown): PsiFailure {
     statusCode: 502,
     upstreamStatus,
     message: 'PageSpeed Insights did not return a result for this URL. This is a Google outage, not a problem with the page.',
+  }
+}
+
+/**
+ * Build the `createError` input for a failed PageSpeed Insights call.
+ *
+ * The marker in `data` is what keeps a Google outage out of Sentry. Raise every PageSpeed failure
+ * through here, never through a bare `createError`, or the outage returns as an issue.
+ */
+export function psiFailureErrorOptions(error: unknown): UpstreamFailureErrorOptions {
+  const failure = describePsiFailure(error)
+
+  return {
+    statusCode: failure.statusCode,
+    statusMessage: failure.message,
+    message: failure.message,
+    data: {
+      reason: EXPECTED_UPSTREAM_FAILURE,
+      upstreamStatus: failure.upstreamStatus,
+    },
   }
 }

--- a/shared/sentry.ts
+++ b/shared/sentry.ts
@@ -42,6 +42,53 @@ export function filterKnownClientNoise<T extends SentryClientEvent>(event: T): T
     : event
 }
 
+/**
+ * Marks an error this site raised on purpose because a provider we call failed.
+ *
+ * A Google outage is not a defect in this site. The endpoints still answer the browser with a
+ * gateway status, but Sentry drops the event so the outage cannot fill the issue feed.
+ */
+export const EXPECTED_UPSTREAM_FAILURE = 'expected-upstream-failure'
+
+/** `createError` input for a provider failure. The marker in `data` is what Sentry drops on. */
+export interface UpstreamFailureErrorOptions {
+  statusCode: number
+  statusMessage: string
+  message: string
+  data: {
+    reason: typeof EXPECTED_UPSTREAM_FAILURE
+    upstreamStatus: number | null
+  }
+}
+
+/** Depth guard, so a cyclic `cause` chain cannot loop forever. */
+const MAX_CAUSE_DEPTH = 5
+
+interface UpstreamFailureCarrier {
+  data?: { reason?: unknown }
+  cause?: unknown
+}
+
+export function isExpectedUpstreamFailure(error: unknown, depth = 0): boolean {
+  if (!error || typeof error !== 'object' || depth > MAX_CAUSE_DEPTH)
+    return false
+
+  const carrier = error as UpstreamFailureCarrier
+  if (carrier.data?.reason === EXPECTED_UPSTREAM_FAILURE)
+    return true
+
+  return isExpectedUpstreamFailure(carrier.cause, depth + 1)
+}
+
+interface SentryEventHint {
+  originalException?: unknown
+}
+
+/** Drop the deliberate upstream failure responses. Keep everything else. */
+export function filterExpectedUpstreamFailures<T>(event: T | null, hint?: SentryEventHint): T | null {
+  return isExpectedUpstreamFailure(hint?.originalException) ? null : event
+}
+
 const SECRET_QUERY_PARAM_RE = /\b(key|api_?key|access_token|auth_?token|token|password|secret|signature)=[^&"'\s]+/gi
 
 /** Replace credential query parameter values with a placeholder. */

--- a/tests/crux-request.test.ts
+++ b/tests/crux-request.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable test/no-import-node-test */
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { buildCruxRequestUrl, describeCruxFailure } from '../shared/crux-request.ts'
+import { buildCruxRequestUrl, cruxFailureErrorOptions, describeCruxFailure } from '../shared/crux-request.ts'
+import { EXPECTED_UPSTREAM_FAILURE } from '../shared/sentry.ts'
 
 test('keeps the api key out of the crux request url', () => {
   const url = buildCruxRequestUrl('current')
@@ -45,4 +46,12 @@ test('maps a missing-data 404 to an unprocessable response when it escapes the n
   const failure = describeCruxFailure(Object.assign(new Error('no data'), { statusCode: 404 }))
 
   assert.equal(failure.statusCode, 422)
+})
+
+test('marks a CrUX outage response as an expected upstream failure', () => {
+  const options = cruxFailureErrorOptions(new Error('fetch failed'))
+
+  assert.equal(options.statusCode, 502)
+  assert.equal(options.data.reason, EXPECTED_UPSTREAM_FAILURE)
+  assert.equal(options.message, options.statusMessage)
 })

--- a/tests/psi-request.test.ts
+++ b/tests/psi-request.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable test/no-import-node-test */
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { buildPsiRequestUrl, describePsiFailure } from '../shared/psi-request.ts'
+import { buildPsiRequestUrl, describePsiFailure, psiFailureErrorOptions } from '../shared/psi-request.ts'
+import { EXPECTED_UPSTREAM_FAILURE } from '../shared/sentry.ts'
 
 test('keeps the api key out of the request url', () => {
   const url = new URL(buildPsiRequestUrl('https://corporate.walmart.com', 'mobile'))
@@ -43,4 +44,20 @@ test('maps a network failure with no status to a gateway failure', () => {
 
   assert.equal(failure.statusCode, 502)
   assert.equal(failure.upstreamStatus, null)
+})
+
+test('marks a PageSpeed outage response as an expected upstream failure', () => {
+  const options = psiFailureErrorOptions(Object.assign(new Error('fetch failed'), { response: { status: 500 } }))
+
+  assert.equal(options.statusCode, 502)
+  assert.equal(options.data.reason, EXPECTED_UPSTREAM_FAILURE)
+  assert.equal(options.data.upstreamStatus, 500)
+  assert.equal(options.message, options.statusMessage)
+})
+
+test('marks a rejected target url as an expected upstream failure too', () => {
+  const options = psiFailureErrorOptions(Object.assign(new Error('bad request'), { statusCode: 400 }))
+
+  assert.equal(options.statusCode, 422)
+  assert.equal(options.data.reason, EXPECTED_UPSTREAM_FAILURE)
 })

--- a/tests/sentry-filter.test.ts
+++ b/tests/sentry-filter.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable test/no-import-node-test */
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { filterKnownClientNoise } from '../shared/sentry.ts'
+import { EXPECTED_UPSTREAM_FAILURE, filterExpectedUpstreamFailures, filterKnownClientNoise } from '../shared/sentry.ts'
 
 const manifestFetchFailure = {
   exception: {
@@ -32,4 +32,48 @@ test('keeps other stackless fetch failures', () => {
   }
 
   assert.equal(filterKnownClientNoise(apiFetchFailure), apiFetchFailure)
+})
+
+const outageEvent = {
+  exception: {
+    values: [{
+      type: 'Error',
+      value: 'PageSpeed Insights did not return a result for this URL. This is a Google outage, not a problem with the page.',
+    }],
+  },
+}
+
+test('drops a response this site raised for a known upstream failure', () => {
+  const outage = {
+    statusCode: 502,
+    message: 'PageSpeed Insights did not return a result for this URL.',
+    data: { reason: EXPECTED_UPSTREAM_FAILURE, upstreamStatus: 500 },
+  }
+
+  assert.equal(filterExpectedUpstreamFailures(outageEvent, { originalException: outage }), null)
+})
+
+test('drops an upstream failure that another error wraps', () => {
+  const wrapped = new Error('handler failed', {
+    cause: { statusCode: 502, data: { reason: EXPECTED_UPSTREAM_FAILURE, upstreamStatus: null } },
+  })
+
+  assert.equal(filterExpectedUpstreamFailures(outageEvent, { originalException: wrapped }), null)
+})
+
+test('keeps a server error that is not a known upstream failure', () => {
+  const bug = Object.assign(new TypeError('Cannot read properties of undefined'), { statusCode: 500 })
+
+  assert.equal(filterExpectedUpstreamFailures(outageEvent, { originalException: bug }), outageEvent)
+})
+
+test('keeps an event with no hint', () => {
+  assert.equal(filterExpectedUpstreamFailures(outageEvent), outageEvent)
+})
+
+test('survives an error whose cause points back at itself', () => {
+  const cyclic: { cause?: unknown } = {}
+  cyclic.cause = cyclic
+
+  assert.equal(filterExpectedUpstreamFailures(outageEvent, { originalException: cyclic }), outageEvent)
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Every PageSpeed Insights outage opens a Sentry issue. `fetchPSI` raises a 502 for an upstream failure, and anything 500 or above reaches Sentry as an unhandled nitro error, so a Google problem reads as a site problem:

```
Error: PageSpeed Insights did not return a result for this URL. This is a Google outage, not a problem with the page.
  GET /api/tools/page-size?url=https:%2F%2Fygovietnam.com%2Fgameplay%2Fmaster-duel%2Fbreakdown%2FBranded&strategy=mobile
```

`psiFailureErrorOptions` now stamps `data.reason = 'expected-upstream-failure'` on the error it builds, and the server `beforeSend` drops those through `hint.originalException`. The browser still gets the same status and the same message. `fetchCrux` raises the identical kind of error, so it goes through `cruxFailureErrorOptions` too.

The part I am least sure about: `hint.originalException` is the only handle Sentry gives on the thrown object, and the error crosses `defineCachedEventHandler` before the nitro error hook sees it. There is a short `cause` walk in `isExpectedUpstreamFailure` in case something wraps it, but if a future nitro release clones the error rather than rethrowing it, the marker travels and the filter still works only if `data` survives the clone. If these issues reappear in Sentry that is the first thing to check.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).