### PR TITLE
chore: adopt the shared eslint base config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,15 +6,7 @@ export default antfu({
     sfcBlocks: false,
   },
   typescript: true,
-  rules: {
-    'node/prefer-global/process': 'off',
-    'node/prefer-global/buffer': 'off',
-  },
-  ignores: [
-    '.data/**',
-    '.claude/**',
-  ],
-}, ...harlanzw(), {
+}, ...harlanzw({ base: { type: 'app' } }), {
   files: ['content/**/*.md/*.{js,jsx,ts,tsx}'],
   rules: {
     'harlanzw/nuxt-no-side-effects-in-setup': 'off',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.17.1
-      version: 0.17.1
+      specifier: ^0.20.0
+      version: 0.20.0
     fuse.js:
       specifier: ^7.5.0
       version: 7.5.0
@@ -443,7 +443,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.20.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       lint-staged:
         specifier: 'catalog:'
         version: 17.3.0
@@ -5786,8 +5786,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.17.1:
-    resolution: {integrity: sha512-JTqWyTYDdMGvo5RDQ1ugq8Y2hGhcSL432WZX3ls52Ie5e+L2MncacI5OrArWB6/8pO7pK3qdm+hgiaFVXmmHxw==}
+  eslint-plugin-harlanzw@0.20.0:
+    resolution: {integrity: sha512-ZhF9pTlsfJ5Bn+8GKpq8o2j0IB23uSLPQDl8VAr859esrI3unTnZXKEzlFQH3/zKsuB4XrZcbQxtEA1inmZguQ==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -15211,7 +15211,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.20.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,8 @@
 minimumReleaseAgeExclude:
-  - '@harlan-zw/nuxt-cloudflare@0.0.18'
+  - '@harlan-zw/nuxt-cloudflare'
   - '@comark/nuxt'
   - '@comark/vue'
   - comark
-  - '@harlan-zw/nuxt-cloudflare'
   - '@harlan-zw/nuxt-dx@0.0.1 || 0.0.9'
   - '@harlan-zw/nuxt-github-sponsors@0.0.1'
   - '@types/three@0.185.0'
@@ -15,6 +14,7 @@ minimumReleaseAgeExclude:
   - '@harlan-zw/comark-content'
   - rangi
   - '@nuxt/scripts@1.3.5'
+  - eslint-plugin-harlanzw@0.20.0
 
 shellEmulator: true
 autoInstallPeers: false
@@ -75,7 +75,7 @@ catalog:
   date-fns: ^4.4.0
   drizzle-orm: ^0.45.2
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.17.1
+  eslint-plugin-harlanzw: ^0.20.0
   fuse.js: ^7.5.0
   h3: ^1.15.11
   lint-staged: ^17.3.0


### PR DESCRIPTION
`eslint-plugin-harlanzw` 0.20.0 ships a `base()` config holding the override
blocks copy-pasted into every repo: the shared ignores, node globals, a
test-file relaxation, markdown code fences, and the pnpm catalog exemption for
`examples/**/package.json`. Same adoption as the nuxt-seo packages.

This also jumps the plugin from 0.17.1 to 0.20.0, which is where the new
warnings below come from, not from `base()`.

**Result:** 304 files before and after, 0 errors, 1 new warning
(`harlanzw/prefer-satisfies`). No file dropped from the run.

Verified by diffing `eslint . --format json` against `main`: the file set and
the message set, not just a clean run.
