### PR TITLE
fix(tools): return a HAR parse failure instead of throwing

### DIFF
--- a/layers/tools/app/composables/useToolHarReport.ts
+++ b/layers/tools/app/composables/useToolHarReport.ts
@@ -1,268 +1,19 @@
-export interface ParsedHarEntry {
-  url: string
-  method: string
-  status: number
-  type: string
-  size: number
-  transferSize: number
-  time: number
-  timings: { blocked: number, dns: number, connect: number, ssl: number, send: number, wait: number, receive: number }
-  startedDateTime: number // ms offset from first request
-  headers: { request: Record<string, string>, response: Record<string, string> }
-  fromCache: boolean
-  protocol: string
-  domain: string
-}
-
-export interface ParsedHar {
-  version: string
-  pages: { id: string, title: string, onLoad: number }[]
-  totalRequests: number
-  totalSize: number
-  totalTransferSize: number
-  totalTime: number
-  entries: ParsedHarEntry[]
-  resourceBreakdown: { type: string, label: string, count: number, size: number }[]
-  statusBreakdown: { status: number, count: number }[]
-  domainBreakdown: { domain: string, count: number, size: number }[]
-  timingPhases: { phase: string, total: number }[]
-  cacheStats: { hits: number, misses: number, hitRate: number }
-  protocolBreakdown: { protocol: string, count: number }[]
-}
-
-const RESOURCE_TYPE_MAP: Record<string, string> = {
-  'text/html': 'document',
-  'text/css': 'stylesheet',
-  'application/javascript': 'script',
-  'text/javascript': 'script',
-  'application/json': 'script',
-  'image/png': 'image',
-  'image/jpeg': 'image',
-  'image/gif': 'image',
-  'image/webp': 'image',
-  'image/avif': 'image',
-  'image/svg+xml': 'image',
-  'font/woff': 'font',
-  'font/woff2': 'font',
-  'application/font-woff': 'font',
-  'application/font-woff2': 'font',
-  'video/mp4': 'media',
-  'audio/mpeg': 'media',
-}
-
-const H2_RE = /^h2.*/
-const H3_RE = /^h3.*/
-
-const RESOURCE_LABELS: Record<string, string> = {
-  document: 'Documents',
-  stylesheet: 'Stylesheets',
-  script: 'Scripts',
-  image: 'Images',
-  font: 'Fonts',
-  media: 'Media',
-  other: 'Other',
-}
-
-function getResourceType(mimeType: string, _resourceType?: string): string {
-  if (_resourceType)
-    return _resourceType.toLowerCase()
-  const normalized = (mimeType.split(';')[0] || '').trim().toLowerCase()
-  return RESOURCE_TYPE_MAP[normalized] || 'other'
-}
-
-function getDomain(url: string): string {
-  return new URL(url).hostname
-}
-
-function headersToRecord(headers: Array<{ name: string, value: string }>): Record<string, string> {
-  const record: Record<string, string> = {}
-  for (const h of headers)
-    record[h.name.toLowerCase()] = h.value
-  return record
-}
-
-function parseHar(input: string | object): ParsedHar {
-  const raw = typeof input === 'string' ? JSON.parse(input) : input
-  const log = (raw as any).log
-
-  if (!log || !log.entries)
-    throw new Error('Invalid HAR file. Expected a "log" object with "entries".')
-
-  const version = log.version || '1.2'
-  const pages = (log.pages || []).map((p: any) => ({
-    id: p.id,
-    title: p.title || 'Untitled',
-    onLoad: p.pageTimings?.onLoad ?? 0,
-  }))
-
-  const firstStarted = log.entries.length
-    ? new Date(log.entries[0].startedDateTime).getTime()
-    : 0
-
-  const typeMap = new Map<string, { count: number, size: number }>()
-  const statusMap = new Map<number, number>()
-  const domainMap = new Map<string, { count: number, size: number }>()
-  const protocolMap = new Map<string, number>()
-  const phases = { blocked: 0, dns: 0, connect: 0, ssl: 0, send: 0, wait: 0, receive: 0 }
-  let cacheHits = 0
-  let cacheMisses = 0
-  let totalSize = 0
-  let totalTransferSize = 0
-  let maxEnd = 0
-
-  const entries: ParsedHarEntry[] = log.entries.map((e: any) => {
-    const entryStart = new Date(e.startedDateTime).getTime()
-    const offset = entryStart - firstStarted
-    const timings = e.timings || {}
-    const t = {
-      blocked: Math.max(0, timings.blocked ?? 0),
-      dns: Math.max(0, timings.dns ?? 0),
-      connect: Math.max(0, timings.connect ?? 0),
-      ssl: Math.max(0, timings.ssl ?? 0),
-      send: Math.max(0, timings.send ?? 0),
-      wait: Math.max(0, timings.wait ?? 0),
-      receive: Math.max(0, timings.receive ?? 0),
-    }
-    const entryTime = e.time || (t.blocked + t.dns + t.connect + t.send + t.wait + t.receive)
-    const endTime = offset + entryTime
-    if (endTime > maxEnd)
-      maxEnd = endTime
-
-    // Sizes
-    const contentSize = e.response?.content?.size ?? 0
-    const xferSize = e._transferSize ?? e.response?.bodySize ?? contentSize
-    totalSize += contentSize
-    totalTransferSize += xferSize
-
-    // Resource type
-    const mimeType = e.response?.content?.mimeType || ''
-    const type = getResourceType(mimeType, e._resourceType)
-
-    // Domain
-    let domain = ''
-    try {
-      domain = getDomain(e.request.url)
-    }
-    catch {
-      // Invalid HAR URLs are grouped under the empty-domain bucket.
-    }
-
-    // Cache
-    const fromCache = !!(e._fromCache || e._fromServiceWorker || (e.response?.status === 304))
-    if (fromCache)
-      cacheHits++
-    else
-      cacheMisses++
-
-    // Protocol
-    const protocol = e._protocol || e.connection || (e.request.httpVersion?.includes('2') ? 'h2' : e.request.httpVersion?.includes('3') ? 'h3' : 'http/1.1')
-
-    // Aggregate type
-    const existing = typeMap.get(type)
-    if (existing) {
-      existing.count++
-      existing.size += xferSize
-    }
-    else {
-      typeMap.set(type, { count: 1, size: xferSize })
-    }
-
-    // Aggregate status
-    const status = e.response?.status ?? 0
-    statusMap.set(status, (statusMap.get(status) || 0) + 1)
-
-    // Aggregate domain
-    if (domain) {
-      const d = domainMap.get(domain)
-      if (d) {
-        d.count++
-        d.size += xferSize
-      }
-      else {
-        domainMap.set(domain, { count: 1, size: xferSize })
-      }
-    }
-
-    // Aggregate protocol
-    const normalizedProtocol = protocol.replace(H2_RE, 'h2').replace(H3_RE, 'h3') || 'http/1.1'
-    protocolMap.set(normalizedProtocol, (protocolMap.get(normalizedProtocol) || 0) + 1)
-
-    // Aggregate timing phases
-    phases.blocked += t.blocked
-    phases.dns += t.dns
-    phases.connect += t.connect
-    phases.ssl += t.ssl
-    phases.send += t.send
-    phases.wait += t.wait
-    phases.receive += t.receive
-
-    const reqHeaders = headersToRecord(e.request?.headers || [])
-    const resHeaders = headersToRecord(e.response?.headers || [])
-
-    return {
-      url: e.request.url,
-      method: e.request.method,
-      status,
-      type,
-      size: contentSize,
-      transferSize: xferSize,
-      time: entryTime,
-      timings: t,
-      startedDateTime: offset,
-      headers: { request: reqHeaders, response: resHeaders },
-      fromCache,
-      protocol: normalizedProtocol,
-      domain,
-    }
-  })
-
-  const resourceBreakdown = Array.from(typeMap.entries())
-    .map(([type, data]) => ({ type, label: RESOURCE_LABELS[type] || type, ...data }))
-    .sort((a, b) => b.size - a.size)
-
-  const statusBreakdown = Array.from(statusMap.entries())
-    .map(([status, count]) => ({ status, count }))
-    .sort((a, b) => a.status - b.status)
-
-  const domainBreakdown = Array.from(domainMap.entries())
-    .map(([domain, data]) => ({ domain, ...data }))
-    .sort((a, b) => b.size - a.size)
-
-  const protocolBreakdown = Array.from(protocolMap.entries())
-    .map(([protocol, count]) => ({ protocol, count }))
-    .sort((a, b) => b.count - a.count)
-
-  const timingPhases = Object.entries(phases)
-    .map(([phase, total]) => ({ phase, total }))
-
-  const totalRequests = entries.length
-  const totalCounted = cacheHits + cacheMisses
-
-  return {
-    version,
-    pages,
-    totalRequests,
-    totalSize,
-    totalTransferSize,
-    totalTime: maxEnd,
-    entries,
-    resourceBreakdown,
-    statusBreakdown,
-    domainBreakdown,
-    timingPhases,
-    cacheStats: {
-      hits: cacheHits,
-      misses: cacheMisses,
-      hitRate: totalCounted > 0 ? cacheHits / totalCounted : 0,
-    },
-    protocolBreakdown,
-  }
-}
+import type { ParsedHar } from '../utils/har'
+import { parseHar } from '../utils/har'
 
 export function useToolHarReport() {
   const report = ref<ParsedHar | null>(null)
   const error = ref<string | null>(null)
   const loading = ref(false)
+
+  function apply(input: string) {
+    const outcome = parseHar(input)
+    if (outcome._tag === 'Err')
+      error.value = outcome.message
+    else
+      report.value = outcome.report
+    loading.value = false
+  }
 
   function loadFromFile(file: File): Promise<void> {
     loading.value = true
@@ -270,10 +21,11 @@ export function useToolHarReport() {
 
     return new Promise<void>((resolve) => {
       const reader = new FileReader()
+      // `FileReader` runs this outside the promise chain, so a throw here reaches
+      // `window.onerror` and no `catch` below can see it. `parseHar` returns its
+      // failure instead of throwing, which is what keeps a bad upload out of Sentry.
       reader.onload = (e) => {
-        const content = e.target?.result as string
-        report.value = parseHar(content)
-        loading.value = false
+        apply(String(e.target?.result ?? ''))
         resolve()
       }
       reader.onerror = () => {
@@ -282,25 +34,13 @@ export function useToolHarReport() {
         resolve()
       }
       reader.readAsText(file)
-    }).catch((err: Error) => {
-      error.value = err.message || 'Failed to parse HAR file'
-      loading.value = false
     })
   }
 
   function loadFromText(text: string) {
     loading.value = true
     error.value = null
-
-    Promise.resolve()
-      .then(() => {
-        report.value = parseHar(text)
-        loading.value = false
-      })
-      .catch((err) => {
-        error.value = err.message || 'Failed to parse HAR file'
-        loading.value = false
-      })
+    apply(text)
   }
 
   function clear() {

--- a/layers/tools/app/pages/tools/har-viewer.vue
+++ b/layers/tools/app/pages/tools/har-viewer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ParsedHarEntry } from '../../composables/useToolHarReport'
+import type { ParsedHarEntry } from '../../utils/har'
 
 definePageMeta({
   breadcrumb: {

--- a/layers/tools/app/utils/har.ts
+++ b/layers/tools/app/utils/har.ts
@@ -1,0 +1,314 @@
+export interface ParsedHarEntry {
+  url: string
+  method: string
+  status: number
+  type: string
+  size: number
+  transferSize: number
+  time: number
+  timings: { blocked: number, dns: number, connect: number, ssl: number, send: number, wait: number, receive: number }
+  startedDateTime: number // ms offset from first request
+  headers: { request: Record<string, string>, response: Record<string, string> }
+  fromCache: boolean
+  protocol: string
+  domain: string
+}
+
+export interface ParsedHar {
+  version: string
+  pages: { id: string, title: string, onLoad: number }[]
+  totalRequests: number
+  totalSize: number
+  totalTransferSize: number
+  totalTime: number
+  entries: ParsedHarEntry[]
+  resourceBreakdown: { type: string, label: string, count: number, size: number }[]
+  statusBreakdown: { status: number, count: number }[]
+  domainBreakdown: { domain: string, count: number, size: number }[]
+  timingPhases: { phase: string, total: number }[]
+  cacheStats: { hits: number, misses: number, hitRate: number }
+  protocolBreakdown: { protocol: string, count: number }[]
+}
+
+/** Why a HAR document could not be read. */
+export type ParseHarReason = 'invalid-json' | 'invalid-har'
+
+/**
+ * Outcome of reading a HAR document.
+ *
+ * A person uploads this file, so a malformed one is ordinary input, not a defect. The parser
+ * returns the failure instead of throwing. Throwing is what sent every bad upload to Sentry: the
+ * throw happened inside a `FileReader` callback, where no `catch` in the composable could see it.
+ */
+export type ParseHarResult
+  = | { _tag: 'Ok', report: ParsedHar }
+    | { _tag: 'Err', reason: ParseHarReason, message: string }
+
+const RESOURCE_TYPE_MAP: Record<string, string> = {
+  'text/html': 'document',
+  'text/css': 'stylesheet',
+  'application/javascript': 'script',
+  'text/javascript': 'script',
+  'application/json': 'script',
+  'image/png': 'image',
+  'image/jpeg': 'image',
+  'image/gif': 'image',
+  'image/webp': 'image',
+  'image/avif': 'image',
+  'image/svg+xml': 'image',
+  'font/woff': 'font',
+  'font/woff2': 'font',
+  'application/font-woff': 'font',
+  'application/font-woff2': 'font',
+  'video/mp4': 'media',
+  'audio/mpeg': 'media',
+}
+
+const H2_RE = /^h2.*/
+const H3_RE = /^h3.*/
+
+const RESOURCE_LABELS: Record<string, string> = {
+  document: 'Documents',
+  stylesheet: 'Stylesheets',
+  script: 'Scripts',
+  image: 'Images',
+  font: 'Fonts',
+  media: 'Media',
+  other: 'Other',
+}
+
+const INVALID_HAR_MESSAGE = 'Invalid HAR file. Expected a "log" object with an "entries" list.'
+const INVALID_JSON_MESSAGE = 'Invalid HAR file. The file is not valid JSON.'
+
+function getResourceType(mimeType: string, resourceType?: string): string {
+  if (resourceType)
+    return resourceType.toLowerCase()
+  const normalized = (mimeType.split(';')[0] || '').trim().toLowerCase()
+  return RESOURCE_TYPE_MAP[normalized] || 'other'
+}
+
+function readDomain(url: string): string {
+  // A HAR can carry a relative or malformed URL. Those entries get the empty-domain bucket.
+  try {
+    return new URL(url).hostname
+  }
+  catch {
+    return ''
+  }
+}
+
+function headersToRecord(headers: unknown): Record<string, string> {
+  const record: Record<string, string> = {}
+  if (!Array.isArray(headers))
+    return record
+  for (const header of headers) {
+    const name = header?.name
+    if (typeof name === 'string')
+      record[name.toLowerCase()] = String(header?.value ?? '')
+  }
+  return record
+}
+
+function readTimestamp(value: unknown): number {
+  const parsed = typeof value === 'string' || typeof value === 'number' ? new Date(value).getTime() : Number.NaN
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function readNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+/**
+ * Read a HAR document into a report, or say why it could not be read.
+ *
+ * Every entry field is optional in practice. Browsers, proxies, and CLI tools all emit HAR, and
+ * they disagree about which keys they write, so each one is read defensively and an entry with no
+ * request is skipped rather than failing the whole upload.
+ */
+export function parseHar(input: string | object): ParseHarResult {
+  let raw: unknown = input
+
+  if (typeof input === 'string') {
+    try {
+      raw = JSON.parse(input)
+    }
+    catch {
+      return { _tag: 'Err', reason: 'invalid-json', message: INVALID_JSON_MESSAGE }
+    }
+  }
+
+  const log = (raw as { log?: unknown } | null)?.log as { entries?: unknown, pages?: unknown, version?: unknown } | undefined
+  if (!log || typeof log !== 'object' || !Array.isArray(log.entries))
+    return { _tag: 'Err', reason: 'invalid-har', message: INVALID_HAR_MESSAGE }
+
+  const rawEntries = (log.entries as Array<Record<string, any> | null>).filter(entry => !!entry?.request)
+
+  const version = typeof log.version === 'string' ? log.version : '1.2'
+  const pages = (Array.isArray(log.pages) ? log.pages : []).map((page: any) => ({
+    id: String(page?.id ?? ''),
+    title: page?.title || 'Untitled',
+    onLoad: readNumber(page?.pageTimings?.onLoad),
+  }))
+
+  const firstStarted = rawEntries.length ? readTimestamp(rawEntries[0]?.startedDateTime) : 0
+
+  const typeMap = new Map<string, { count: number, size: number }>()
+  const statusMap = new Map<number, number>()
+  const domainMap = new Map<string, { count: number, size: number }>()
+  const protocolMap = new Map<string, number>()
+  const phases = { blocked: 0, dns: 0, connect: 0, ssl: 0, send: 0, wait: 0, receive: 0 }
+  let cacheHits = 0
+  let cacheMisses = 0
+  let totalSize = 0
+  let totalTransferSize = 0
+  let maxEnd = 0
+
+  const entries: ParsedHarEntry[] = rawEntries.map((entry: any) => {
+    const offset = readTimestamp(entry.startedDateTime) - firstStarted
+    const timings = entry.timings || {}
+    const t = {
+      blocked: Math.max(0, readNumber(timings.blocked)),
+      dns: Math.max(0, readNumber(timings.dns)),
+      connect: Math.max(0, readNumber(timings.connect)),
+      ssl: Math.max(0, readNumber(timings.ssl)),
+      send: Math.max(0, readNumber(timings.send)),
+      wait: Math.max(0, readNumber(timings.wait)),
+      receive: Math.max(0, readNumber(timings.receive)),
+    }
+    const entryTime = readNumber(entry.time) || (t.blocked + t.dns + t.connect + t.send + t.wait + t.receive)
+    const endTime = offset + entryTime
+    if (endTime > maxEnd)
+      maxEnd = endTime
+
+    // Sizes
+    const contentSize = readNumber(entry.response?.content?.size)
+    const xferSize = readNumber(entry._transferSize, readNumber(entry.response?.bodySize, contentSize))
+    totalSize += contentSize
+    totalTransferSize += xferSize
+
+    // Resource type
+    const mimeType = typeof entry.response?.content?.mimeType === 'string' ? entry.response.content.mimeType : ''
+    const type = getResourceType(mimeType, typeof entry._resourceType === 'string' ? entry._resourceType : undefined)
+
+    const url = typeof entry.request?.url === 'string' ? entry.request.url : ''
+    const domain = readDomain(url)
+
+    // Cache
+    const status = readNumber(entry.response?.status)
+    const fromCache = !!(entry._fromCache || entry._fromServiceWorker || status === 304)
+    if (fromCache)
+      cacheHits++
+    else
+      cacheMisses++
+
+    // Protocol
+    const httpVersion = typeof entry.request?.httpVersion === 'string' ? entry.request.httpVersion : ''
+    const protocol = String(
+      entry._protocol
+      || entry.connection
+      || (httpVersion.includes('2') ? 'h2' : httpVersion.includes('3') ? 'h3' : 'http/1.1'),
+    )
+
+    // Aggregate type
+    const existing = typeMap.get(type)
+    if (existing) {
+      existing.count++
+      existing.size += xferSize
+    }
+    else {
+      typeMap.set(type, { count: 1, size: xferSize })
+    }
+
+    // Aggregate status
+    statusMap.set(status, (statusMap.get(status) || 0) + 1)
+
+    // Aggregate domain
+    if (domain) {
+      const d = domainMap.get(domain)
+      if (d) {
+        d.count++
+        d.size += xferSize
+      }
+      else {
+        domainMap.set(domain, { count: 1, size: xferSize })
+      }
+    }
+
+    // Aggregate protocol
+    const normalizedProtocol = protocol.replace(H2_RE, 'h2').replace(H3_RE, 'h3') || 'http/1.1'
+    protocolMap.set(normalizedProtocol, (protocolMap.get(normalizedProtocol) || 0) + 1)
+
+    // Aggregate timing phases
+    phases.blocked += t.blocked
+    phases.dns += t.dns
+    phases.connect += t.connect
+    phases.ssl += t.ssl
+    phases.send += t.send
+    phases.wait += t.wait
+    phases.receive += t.receive
+
+    return {
+      url,
+      method: typeof entry.request?.method === 'string' ? entry.request.method : '',
+      status,
+      type,
+      size: contentSize,
+      transferSize: xferSize,
+      time: entryTime,
+      timings: t,
+      startedDateTime: offset,
+      headers: {
+        request: headersToRecord(entry.request?.headers),
+        response: headersToRecord(entry.response?.headers),
+      },
+      fromCache,
+      protocol: normalizedProtocol,
+      domain,
+    }
+  })
+
+  const resourceBreakdown = Array.from(typeMap.entries())
+    .map(([type, data]) => ({ type, label: RESOURCE_LABELS[type] || type, ...data }))
+    .sort((a, b) => b.size - a.size)
+
+  const statusBreakdown = Array.from(statusMap.entries())
+    .map(([status, count]) => ({ status, count }))
+    .sort((a, b) => a.status - b.status)
+
+  const domainBreakdown = Array.from(domainMap.entries())
+    .map(([domain, data]) => ({ domain, ...data }))
+    .sort((a, b) => b.size - a.size)
+
+  const protocolBreakdown = Array.from(protocolMap.entries())
+    .map(([protocol, count]) => ({ protocol, count }))
+    .sort((a, b) => b.count - a.count)
+
+  const timingPhases = Object.entries(phases)
+    .map(([phase, total]) => ({ phase, total }))
+
+  const totalRequests = entries.length
+  const totalCounted = cacheHits + cacheMisses
+
+  return {
+    _tag: 'Ok',
+    report: {
+      version,
+      pages,
+      totalRequests,
+      totalSize,
+      totalTransferSize,
+      totalTime: maxEnd,
+      entries,
+      resourceBreakdown,
+      statusBreakdown,
+      domainBreakdown,
+      timingPhases,
+      cacheStats: {
+        hits: cacheHits,
+        misses: cacheMisses,
+        hitRate: totalCounted > 0 ? cacheHits / totalCounted : 0,
+      },
+      protocolBreakdown,
+    },
+  }
+}

--- a/tests/har-report.test.ts
+++ b/tests/har-report.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseHar } from '../layers/tools/app/utils/har.ts'
+
+function harEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    startedDateTime: '2026-08-17T20:59:00.000Z',
+    time: 120,
+    request: { url: 'https://example.com/app.js', method: 'GET', httpVersion: 'h2' },
+    response: { status: 200, content: { size: 2048, mimeType: 'text/javascript' } },
+    timings: { blocked: 10, dns: 5, connect: 5, ssl: 0, send: 0, wait: 80, receive: 20 },
+    ...overrides,
+  }
+}
+
+test('rejects text that is not JSON without throwing', () => {
+  const result = parseHar('not json at all')
+
+  assert.equal(result._tag, 'Err')
+  assert.equal(result._tag === 'Err' && result.reason, 'invalid-json')
+})
+
+test('rejects a JSON document with no log entries', () => {
+  const result = parseHar(JSON.stringify({ log: { version: '1.2' } }))
+
+  assert.equal(result._tag, 'Err')
+  assert.equal(result._tag === 'Err' && result.reason, 'invalid-har')
+})
+
+test('rejects a HAR whose entries are not a list', () => {
+  const result = parseHar(JSON.stringify({ log: { entries: { url: 'https://example.com' } } }))
+
+  assert.equal(result._tag, 'Err')
+  assert.equal(result._tag === 'Err' && result.reason, 'invalid-har')
+})
+
+test('parses a HAR into totals a reader can act on', () => {
+  const result = parseHar(JSON.stringify({
+    log: {
+      version: '1.2',
+      pages: [{ id: 'page_1', title: 'Example', pageTimings: { onLoad: 900 } }],
+      entries: [
+        harEntry(),
+        harEntry({
+          startedDateTime: '2026-08-17T20:59:00.500Z',
+          request: { url: 'https://cdn.example.org/logo.png', method: 'GET', httpVersion: 'h2' },
+          response: { status: 304, content: { size: 512, mimeType: 'image/png' } },
+        }),
+      ],
+    },
+  }))
+
+  assert.equal(result._tag, 'Ok')
+  if (result._tag !== 'Ok')
+    return
+
+  assert.equal(result.report.totalRequests, 2)
+  assert.equal(result.report.totalSize, 2560)
+  assert.equal(result.report.pages[0]?.title, 'Example')
+  assert.equal(result.report.cacheStats.hits, 1)
+  assert.deepEqual(
+    result.report.domainBreakdown.map(domain => domain.domain).sort(),
+    ['cdn.example.org', 'example.com'],
+  )
+})
+
+test('keeps an entry with no request object out of the report instead of failing', () => {
+  const result = parseHar(JSON.stringify({
+    log: { entries: [harEntry(), { startedDateTime: '2026-08-17T20:59:01.000Z' }] },
+  }))
+
+  assert.equal(result._tag, 'Ok')
+  assert.equal(result._tag === 'Ok' && result.report.totalRequests, 1)
+})


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Someone dropped a file that was not a HAR on /tools/har-viewer and it landed in Sentry as UNLIGHTHOUSE-A:

```
Error: Invalid HAR file. Expected a "log" object with "entries".
  ./layers/tools/app/composables/useToolHarReport.ts in a.onload
  mechanism: auto.browser.global_handlers.onerror
```

`parseHar` threw from inside `FileReader.onload`. That callback runs outside the promise chain, so the `.catch` sitting on the returned promise never saw the throw and it went straight to `window.onerror`. `loadFromText` had the same parser but a real catch, which is why only the upload path reported.

`parseHar` moves to `layers/tools/app/utils/har.ts` and returns `{ _tag: 'Ok' }` or `{ _tag: 'Err', reason }`, so neither caller can throw. While in there I made the entry reader defensive: `e.request.url` on an entry with no `request` was a second uncaught TypeError waiting to happen, and those entries are now skipped instead of failing the whole file.

Sentry only ever caught the missing-`log` case, so the JSON syntax error message is my guess at what reads well. Happy to change the wording.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).