### PR TITLE
fix(sentry): stop reporting the Carbon Ads script crash

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,7 +4,7 @@ import { defineNuxtConfig } from 'nuxt/config'
 import { resolve } from 'pathe'
 import { gray, logger } from './logger'
 import { CLOUDFLARE_REQUIRED_SECRETS } from './shared/cloudflare'
-import { EXPECTED_UPSTREAM_FAILURE_MESSAGE_RE, STACKLESS_FETCH_FAILURE_MESSAGE_RE } from './shared/sentry'
+import { CARBON_ADS_SCRIPT_URL_RE, EXPECTED_UPSTREAM_FAILURE_MESSAGE_RE, STACKLESS_FETCH_FAILURE_MESSAGE_RE } from './shared/sentry'
 
 // workerd installs its Node-compatible `console` as soon as anything in the
 // bundle imports `node:console` (undici, via node-fetch-native, does). That
@@ -40,6 +40,10 @@ export default defineNuxtConfig({
       // would also drop the same failure raised from site code, so this rule needs
       // the empty frame list as well.
       dropStacklessErrors: [STACKLESS_FETCH_FAILURE_MESSAGE_RE],
+      // The Carbon Ads script crashes on its own timer after a client navigation
+      // unmounts it. This site cannot change the provider's code, so it drops
+      // every report whose crash frame is that script.
+      denyUrls: [CARBON_ADS_SCRIPT_URL_RE],
     },
   },
 

--- a/shared/sentry.ts
+++ b/shared/sentry.ts
@@ -38,3 +38,18 @@ export const EXPECTED_UPSTREAM_FAILURE_MESSAGE_RE
  * stack frame. The same message with a stack is a defect here and still reports.
  */
 export const STACKLESS_FETCH_FAILURE_MESSAGE_RE = /^TypeError: Failed to fetch$/
+
+/**
+ * The Carbon Ads script, which `ScriptCarbonAds` loads on every documentation page.
+ *
+ * The component keys the ad on the route path, so a client navigation unmounts it and
+ * `@nuxt/scripts` removes the `#_carbonads_js` script element. carbon.js still holds a timer
+ * that reads `document.getElementById('_carbonads_js').src`, so the timer throws on an element
+ * this site already removed. The crash is in the provider's code, and no site frame appears
+ * below the Sentry timer wrapper.
+ *
+ * `nuxtSentry.policy.denyUrls` feeds the Sentry client `denyUrls` option, which matches the
+ * crash frame URL. The Report Policy `denyUrls` Drop Rule needs every frame to match, so it
+ * does not drop this report on its own.
+ */
+export const CARBON_ADS_SCRIPT_URL_RE = /^https?:\/\/(?:[^/]*\.)?carbonads\.(?:com|net)\//i

--- a/tests/sentry-filter.test.ts
+++ b/tests/sentry-filter.test.ts
@@ -2,10 +2,10 @@
 import type { ErrorReport, ReportPolicy } from '@harlan-zw/nuxt-sentry/server'
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { decideReport } from '@harlan-zw/nuxt-sentry/server'
+import { createClientNoiseOptions, decideReport } from '@harlan-zw/nuxt-sentry/server'
 import { describeCruxFailure } from '../shared/crux-request.ts'
 import { describePsiFailure } from '../shared/psi-request.ts'
-import { EXPECTED_UPSTREAM_FAILURE_MESSAGE_RE, STACKLESS_FETCH_FAILURE_MESSAGE_RE } from '../shared/sentry.ts'
+import { CARBON_ADS_SCRIPT_URL_RE, EXPECTED_UPSTREAM_FAILURE_MESSAGE_RE, STACKLESS_FETCH_FAILURE_MESSAGE_RE } from '../shared/sentry.ts'
 
 const upstreamErrors = [
   Object.assign(new Error('rate limited'), { response: { status: 429 } }),
@@ -41,7 +41,11 @@ const clientPolicy: ReportPolicy = {
     flags: STACKLESS_FETCH_FAILURE_MESSAGE_RE.flags,
   }],
   dropBreadcrumbMessages: [],
-  denyUrls: [],
+  denyUrls: [{
+    _tag: 'pattern',
+    source: CARBON_ADS_SCRIPT_URL_RE.source,
+    flags: CARBON_ADS_SCRIPT_URL_RE.flags,
+  }],
   secretKeys: [],
 }
 
@@ -67,4 +71,19 @@ test('keeps the same failure when a stack names site code', () => {
   const report = fetchFailureReport([{ filename: 'https://unlighthouse.dev/_nuxt/entry.js' }])
 
   assert.deepEqual(decideReport(report, undefined, clientPolicy), { _tag: 'send' })
+})
+
+/** The frame the ad script crashes in after the site unmounts its script element. */
+const CARBON_ADS_FRAME_URL = 'https://cdn.carbonads.com/carbon.js'
+
+test('drops an error the ad script raises', () => {
+  const { denyUrls } = createClientNoiseOptions(clientPolicy)
+
+  assert.ok(denyUrls.some(pattern => pattern.test(CARBON_ADS_FRAME_URL)))
+})
+
+test('keeps an error a site chunk raises', () => {
+  const { denyUrls } = createClientNoiseOptions(clientPolicy)
+
+  assert.ok(!denyUrls.some(pattern => pattern.test('https://unlighthouse.dev/_nuxt/entry.js')))
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Carbon Ads keeps a timer that reads back its own script element. Every docs navigation re-keys the ad, `@nuxt/scripts` removes that element, and the provider timer then throws into Sentry as UNLIGHTHOUSE-B. The page keeps working, and no site frame appears under the Sentry timer wrapper, so the report is noise from code this site does not own.

Left alone: the `route.path` key in `Ads.vue` is what triggers the teardown. Removing it would stop the ad refreshing per page, which is a revenue call rather than a bug fix. Say the word if you want that instead.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).