### PR TITLE
fix(tools): return a Lighthouse parse failure instead of throwing

### DIFF
--- a/layers/tools/app/composables/useToolLighthouseReport.ts
+++ b/layers/tools/app/composables/useToolLighthouseReport.ts
@@ -1,152 +1,24 @@
-import type {
-  LighthouseAudit,
-  LighthouseCategory,
-  LighthouseResult,
-  ParsedLighthouseReport,
-  PerformanceMetric,
-} from '../types/lighthouse'
+import type { ParsedLighthouseReport } from '../types/lighthouse'
 import { computed, ref } from 'vue'
-
-// Performance metric definitions
-const PERF_METRIC_IDS = [
-  'first-contentful-paint',
-  'speed-index',
-  'largest-contentful-paint',
-  'total-blocking-time',
-  'cumulative-layout-shift',
-  'interactive', // TTI
-]
-
-const CORE_WEB_VITALS = [
-  'largest-contentful-paint',
-  'cumulative-layout-shift',
-  'total-blocking-time', // Proxy for INP in lab
-]
-
-const METRIC_SHORT_NAMES: Record<string, string> = {
-  'first-contentful-paint': 'FCP',
-  'speed-index': 'SI',
-  'largest-contentful-paint': 'LCP',
-  'total-blocking-time': 'TBT',
-  'cumulative-layout-shift': 'CLS',
-  'interactive': 'TTI',
-}
-
-function getDevice(report: LighthouseResult): 'mobile' | 'desktop' {
-  if (report.configSettings.formFactor)
-    return report.configSettings.formFactor
-  if (report.configSettings.screenEmulation?.mobile)
-    return 'mobile'
-  return 'desktop'
-}
-
-function extractPerformanceMetrics(report: LighthouseResult): PerformanceMetric[] {
-  const metrics: PerformanceMetric[] = []
-
-  for (const id of PERF_METRIC_IDS) {
-    const audit = report.audits[id]
-    if (!audit)
-      continue
-
-    metrics.push({
-      id,
-      name: METRIC_SHORT_NAMES[id] || audit.title,
-      value: audit.numericValue ?? 0,
-      displayValue: audit.displayValue ?? '',
-      score: audit.score,
-      unit: audit.numericUnit === 'unitless' ? 'unitless' : 'ms',
-      isCoreWebVital: CORE_WEB_VITALS.includes(id),
-    })
-  }
-
-  return metrics
-}
-
-function getAuditsByType(report: LighthouseResult, category: LighthouseCategory | undefined) {
-  if (!category)
-    return { opportunities: [], diagnostics: [], passed: [] }
-
-  const opportunities: LighthouseAudit[] = []
-  const diagnostics: LighthouseAudit[] = []
-  const passed: LighthouseAudit[] = []
-
-  for (const ref of category.auditRefs) {
-    const audit = report.audits[ref.id]
-    if (!audit)
-      continue
-
-    // Skip metrics, they're handled separately
-    if (ref.group === 'metrics')
-      continue
-
-    if (audit.score === 1 || audit.scoreDisplayMode === 'notApplicable') {
-      passed.push(audit)
-    }
-    else if (audit.details?.type === 'opportunity') {
-      opportunities.push(audit)
-    }
-    else if (ref.group === 'diagnostics' || audit.scoreDisplayMode === 'informative') {
-      diagnostics.push(audit)
-    }
-    else if (audit.score !== null && audit.score < 1) {
-      diagnostics.push(audit)
-    }
-  }
-
-  // Sort opportunities by savings
-  opportunities.sort((a, b) => {
-    const aSavings = a.details?.type === 'opportunity'
-      ? (a.details.overallSavingsMs ?? 0)
-      : 0
-    const bSavings = b.details?.type === 'opportunity'
-      ? (b.details.overallSavingsMs ?? 0)
-      : 0
-    return bSavings - aSavings
-  })
-
-  return { opportunities, diagnostics, passed }
-}
-
-function parseReport(input: string | object): ParsedLighthouseReport {
-  const raw: LighthouseResult = typeof input === 'string' ? JSON.parse(input) : input
-
-  // Validate it's a Lighthouse report
-  if (!raw.lighthouseVersion || !raw.categories) {
-    throw new Error('Invalid Lighthouse report format. Expected lighthouseVersion and categories.')
-  }
-
-  const perfCategory = raw.categories.performance
-  const { opportunities, diagnostics, passed } = getAuditsByType(raw, perfCategory)
-
-  return {
-    raw,
-    url: raw.finalUrl || raw.requestedUrl,
-    fetchTime: new Date(raw.fetchTime),
-    device: getDevice(raw),
-    version: raw.lighthouseVersion,
-    categories: {
-      performance: raw.categories.performance ?? null,
-      accessibility: raw.categories.accessibility ?? null,
-      bestPractices: raw.categories['best-practices'] ?? null,
-      seo: raw.categories.seo ?? null,
-      pwa: raw.categories.pwa ?? null,
-    },
-    performanceMetrics: extractPerformanceMetrics(raw),
-    opportunities,
-    diagnostics,
-    passedAudits: passed,
-    screenshot: raw.fullPageScreenshot?.screenshot ?? null,
-  }
-}
+import { parseLighthouseReport } from '../utils/lighthouse'
 
 export function useToolLighthouseReport() {
   const report = ref<ParsedLighthouseReport | null>(null)
   const error = ref<string | null>(null)
   const loading = ref(false)
 
+  function apply(input: string | object) {
+    const outcome = parseLighthouseReport(input)
+    if (outcome._tag === 'Err')
+      error.value = outcome.message
+    else
+      report.value = outcome.report
+    loading.value = false
+  }
+
   function loadReport(input: string | object) {
     error.value = null
-    report.value = parseReport(input)
+    apply(input)
   }
 
   function loadFromFile(file: File): Promise<void> {
@@ -155,40 +27,26 @@ export function useToolLighthouseReport() {
 
     return new Promise<void>((resolve) => {
       const reader = new FileReader()
-
+      // `FileReader` runs this outside the promise chain, so a throw here reaches
+      // `window.onerror` and no `catch` below can see it. `parseLighthouseReport` returns its
+      // failure instead of throwing, which is what keeps a bad upload out of Sentry.
       reader.onload = (e) => {
-        const content = e.target?.result as string
-        report.value = parseReport(content)
-        loading.value = false
+        apply(String(e.target?.result ?? ''))
         resolve()
       }
-
       reader.onerror = () => {
         error.value = 'Failed to read file'
         loading.value = false
         resolve()
       }
-
       reader.readAsText(file)
-    }).catch((err: Error) => {
-      error.value = err.message || 'Failed to parse JSON'
-      loading.value = false
     })
   }
 
   function loadFromText(text: string) {
     loading.value = true
     error.value = null
-
-    Promise.resolve()
-      .then(() => {
-        report.value = parseReport(text)
-        loading.value = false
-      })
-      .catch((err) => {
-        error.value = err.message || 'Failed to parse JSON'
-        loading.value = false
-      })
+    apply(text)
   }
 
   function clear() {
@@ -196,7 +54,6 @@ export function useToolLighthouseReport() {
     error.value = null
   }
 
-  // Computed helpers
   const hasPerformance = computed(() => !!report.value?.categories.performance)
   const hasAccessibility = computed(() => !!report.value?.categories.accessibility)
   const hasBestPractices = computed(() => !!report.value?.categories.bestPractices)

--- a/layers/tools/app/pages/tools/lighthouse-report-viewer.vue
+++ b/layers/tools/app/pages/tools/lighthouse-report-viewer.vue
@@ -216,7 +216,7 @@ const categoryDisplayData = computed(() => {
               {{ report.url }}
             </a>
           </div>
-          <div class="text-xs text-gray-500 shrink-0">
+          <div v-if="report.fetchTime" class="text-xs text-gray-500 shrink-0">
             {{ report.fetchTime.toLocaleString() }}
           </div>
         </div>

--- a/layers/tools/app/types/lighthouse.ts
+++ b/layers/tools/app/types/lighthouse.ts
@@ -150,7 +150,7 @@ export interface PerformanceMetric {
 export interface ParsedLighthouseReport {
   raw: LighthouseResult
   url: string
-  fetchTime: Date
+  fetchTime: Date | null
   device: 'mobile' | 'desktop'
   version: string
   categories: {

--- a/layers/tools/app/utils/lighthouse.ts
+++ b/layers/tools/app/utils/lighthouse.ts
@@ -156,7 +156,8 @@ export function parseLighthouseReport(input: string | object): ParseLighthouseRe
   const performance = readCategory(categories, 'performance')
   const { opportunities, diagnostics, passed } = getAuditsByType(audits, performance ?? undefined)
 
-  const fetchTime = new Date(typeof raw.fetchTime === 'string' ? raw.fetchTime : Number.NaN)
+  const parsedFetchTime = typeof raw.fetchTime === 'string' ? new Date(raw.fetchTime) : null
+  const fetchTime = parsedFetchTime && !Number.isNaN(parsedFetchTime.getTime()) ? parsedFetchTime : null
   const screenshot = isRecord(raw.fullPageScreenshot) && isRecord(raw.fullPageScreenshot.screenshot)
     ? raw.fullPageScreenshot.screenshot as ParsedLighthouseReport['screenshot']
     : null

--- a/layers/tools/app/utils/lighthouse.ts
+++ b/layers/tools/app/utils/lighthouse.ts
@@ -1,0 +1,186 @@
+import type {
+  LighthouseAudit,
+  LighthouseCategory,
+  LighthouseResult,
+  ParsedLighthouseReport,
+  PerformanceMetric,
+} from '../types/lighthouse'
+
+/** Why a Lighthouse JSON report could not be read. */
+export type ParseLighthouseReason = 'invalid-json' | 'invalid-report'
+
+/**
+ * Outcome of reading a Lighthouse JSON report.
+ *
+ * A person uploads this file, so a malformed one is ordinary input, not a defect. The parser
+ * returns the failure instead of throwing. Throwing is what sent every bad upload to Sentry: the
+ * throw happened inside a `FileReader` callback, where no `catch` in the composable could see it.
+ */
+export type ParseLighthouseResult
+  = | { _tag: 'Ok', report: ParsedLighthouseReport }
+    | { _tag: 'Err', reason: ParseLighthouseReason, message: string }
+
+const INVALID_JSON_MESSAGE = 'Invalid Lighthouse report. The file is not valid JSON.'
+const INVALID_REPORT_MESSAGE = 'Invalid Lighthouse report. Expected a "lighthouseVersion" string and a "categories" object.'
+
+const PERF_METRIC_IDS = [
+  'first-contentful-paint',
+  'speed-index',
+  'largest-contentful-paint',
+  'total-blocking-time',
+  'cumulative-layout-shift',
+  'interactive', // TTI
+]
+
+const CORE_WEB_VITALS = [
+  'largest-contentful-paint',
+  'cumulative-layout-shift',
+  'total-blocking-time', // Proxy for INP in lab
+]
+
+const METRIC_SHORT_NAMES: Record<string, string> = {
+  'first-contentful-paint': 'FCP',
+  'speed-index': 'SI',
+  'largest-contentful-paint': 'LCP',
+  'total-blocking-time': 'TBT',
+  'cumulative-layout-shift': 'CLS',
+  'interactive': 'TTI',
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function getDevice(settings: LighthouseResult['configSettings'] | undefined): 'mobile' | 'desktop' {
+  if (settings?.formFactor === 'mobile' || settings?.formFactor === 'desktop')
+    return settings.formFactor
+  if (settings?.screenEmulation?.mobile)
+    return 'mobile'
+  return 'desktop'
+}
+
+function extractPerformanceMetrics(audits: Record<string, LighthouseAudit>): PerformanceMetric[] {
+  const metrics: PerformanceMetric[] = []
+
+  for (const id of PERF_METRIC_IDS) {
+    const audit = audits[id]
+    if (!audit)
+      continue
+
+    metrics.push({
+      id,
+      name: METRIC_SHORT_NAMES[id] || audit.title,
+      value: audit.numericValue ?? 0,
+      displayValue: audit.displayValue ?? '',
+      score: audit.score,
+      unit: audit.numericUnit === 'unitless' ? 'unitless' : 'ms',
+      isCoreWebVital: CORE_WEB_VITALS.includes(id),
+    })
+  }
+
+  return metrics
+}
+
+function getAuditsByType(audits: Record<string, LighthouseAudit>, category: LighthouseCategory | undefined) {
+  const opportunities: LighthouseAudit[] = []
+  const diagnostics: LighthouseAudit[] = []
+  const passed: LighthouseAudit[] = []
+
+  const refs = Array.isArray(category?.auditRefs) ? category.auditRefs : []
+
+  for (const ref of refs) {
+    const audit = audits[ref?.id]
+    if (!audit)
+      continue
+
+    // Metrics render in their own panel, so they never join the audit lists.
+    if (ref.group === 'metrics')
+      continue
+
+    if (audit.score === 1 || audit.scoreDisplayMode === 'notApplicable') {
+      passed.push(audit)
+    }
+    else if (audit.details?.type === 'opportunity') {
+      opportunities.push(audit)
+    }
+    else if (ref.group === 'diagnostics' || audit.scoreDisplayMode === 'informative') {
+      diagnostics.push(audit)
+    }
+    else if (audit.score !== null && audit.score < 1) {
+      diagnostics.push(audit)
+    }
+  }
+
+  opportunities.sort((a, b) => {
+    const aSavings = a.details?.type === 'opportunity' ? (a.details.overallSavingsMs ?? 0) : 0
+    const bSavings = b.details?.type === 'opportunity' ? (b.details.overallSavingsMs ?? 0) : 0
+    return bSavings - aSavings
+  })
+
+  return { opportunities, diagnostics, passed }
+}
+
+function readCategory(categories: Record<string, any>, id: string): LighthouseCategory | null {
+  const category = categories[id]
+  return isRecord(category) ? category as LighthouseCategory : null
+}
+
+/**
+ * Read a Lighthouse JSON report into a viewer model, or say why it could not be read.
+ *
+ * Chrome DevTools, the Lighthouse CLI, and the PageSpeed Insights API all produce this shape and
+ * disagree about the optional keys, so every field beyond `lighthouseVersion` and `categories` is
+ * read defensively rather than failing the whole upload.
+ */
+export function parseLighthouseReport(input: string | object): ParseLighthouseResult {
+  let raw: unknown = input
+
+  if (typeof input === 'string') {
+    try {
+      raw = JSON.parse(input)
+    }
+    catch {
+      return { _tag: 'Err', reason: 'invalid-json', message: INVALID_JSON_MESSAGE }
+    }
+  }
+
+  if (!isRecord(raw))
+    return { _tag: 'Err', reason: 'invalid-report', message: INVALID_REPORT_MESSAGE }
+
+  if (typeof raw.lighthouseVersion !== 'string' || !raw.lighthouseVersion || !isRecord(raw.categories))
+    return { _tag: 'Err', reason: 'invalid-report', message: INVALID_REPORT_MESSAGE }
+
+  const result = raw as unknown as LighthouseResult
+  const categories = raw.categories as Record<string, any>
+  const audits = isRecord(raw.audits) ? raw.audits as Record<string, LighthouseAudit> : {}
+  const performance = readCategory(categories, 'performance')
+  const { opportunities, diagnostics, passed } = getAuditsByType(audits, performance ?? undefined)
+
+  const fetchTime = new Date(typeof raw.fetchTime === 'string' ? raw.fetchTime : Number.NaN)
+  const screenshot = isRecord(raw.fullPageScreenshot) && isRecord(raw.fullPageScreenshot.screenshot)
+    ? raw.fullPageScreenshot.screenshot as ParsedLighthouseReport['screenshot']
+    : null
+
+  return {
+    _tag: 'Ok',
+    report: {
+      raw: result,
+      url: (typeof raw.finalUrl === 'string' && raw.finalUrl) || (typeof raw.requestedUrl === 'string' ? raw.requestedUrl : ''),
+      fetchTime,
+      device: getDevice(isRecord(raw.configSettings) ? raw.configSettings as LighthouseResult['configSettings'] : undefined),
+      version: raw.lighthouseVersion,
+      categories: {
+        performance,
+        accessibility: readCategory(categories, 'accessibility'),
+        bestPractices: readCategory(categories, 'best-practices'),
+        seo: readCategory(categories, 'seo'),
+        pwa: readCategory(categories, 'pwa'),
+      },
+      performanceMetrics: extractPerformanceMetrics(audits),
+      opportunities,
+      diagnostics,
+      passedAudits: passed,
+      screenshot,
+    },
+  }
+}

--- a/tests/lighthouse-report.test.ts
+++ b/tests/lighthouse-report.test.ts
@@ -1,0 +1,122 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseLighthouseReport } from '../layers/tools/app/utils/lighthouse.ts'
+
+function lighthouseReport(overrides: Record<string, unknown> = {}) {
+  return {
+    lighthouseVersion: '12.2.1',
+    requestedUrl: 'https://example.com',
+    finalUrl: 'https://example.com/',
+    fetchTime: '2026-08-24T09:59:00.000Z',
+    configSettings: { formFactor: 'mobile', throttlingMethod: 'simulate' },
+    categories: {
+      'performance': {
+        id: 'performance',
+        title: 'Performance',
+        score: 0.42,
+        auditRefs: [
+          { id: 'largest-contentful-paint', weight: 25, group: 'metrics' },
+          { id: 'render-blocking-resources', weight: 0, group: 'diagnostics' },
+          { id: 'uses-long-cache-ttl', weight: 0 },
+        ],
+      },
+      'best-practices': { id: 'best-practices', title: 'Best Practices', score: 1, auditRefs: [] },
+    },
+    audits: {
+      'largest-contentful-paint': {
+        id: 'largest-contentful-paint',
+        title: 'Largest Contentful Paint',
+        score: 0.1,
+        scoreDisplayMode: 'numeric',
+        displayValue: '9.9 s',
+        numericValue: 9901,
+        numericUnit: 'millisecond',
+      },
+      'render-blocking-resources': {
+        id: 'render-blocking-resources',
+        title: 'Eliminate render-blocking resources',
+        score: 0.3,
+        scoreDisplayMode: 'numeric',
+        details: { type: 'opportunity', headings: [], items: [], overallSavingsMs: 800 },
+      },
+      'uses-long-cache-ttl': {
+        id: 'uses-long-cache-ttl',
+        title: 'Serve static assets with an efficient cache policy',
+        score: 1,
+        scoreDisplayMode: 'numeric',
+      },
+    },
+    ...overrides,
+  }
+}
+
+test('rejects text that is not JSON without throwing', () => {
+  const result = parseLighthouseReport('not json at all')
+
+  assert.equal(result._tag, 'Err')
+  assert.equal(result._tag === 'Err' && result.reason, 'invalid-json')
+})
+
+test('rejects JSON that is not a Lighthouse report', () => {
+  const result = parseLighthouseReport(JSON.stringify({ log: { entries: [] } }))
+
+  assert.equal(result._tag, 'Err')
+  assert.equal(result._tag === 'Err' && result.reason, 'invalid-report')
+})
+
+test('rejects a report with a version but no categories', () => {
+  const result = parseLighthouseReport(JSON.stringify({ lighthouseVersion: '12.2.1', audits: {} }))
+
+  assert.equal(result._tag, 'Err')
+  assert.equal(result._tag === 'Err' && result.reason, 'invalid-report')
+})
+
+test('rejects a JSON array', () => {
+  const result = parseLighthouseReport(JSON.stringify([{ lighthouseVersion: '12.2.1', categories: {} }]))
+
+  assert.equal(result._tag, 'Err')
+  assert.equal(result._tag === 'Err' && result.reason, 'invalid-report')
+})
+
+test('parses a report into scores a reader can act on', () => {
+  const result = parseLighthouseReport(JSON.stringify(lighthouseReport()))
+
+  assert.equal(result._tag, 'Ok')
+  if (result._tag !== 'Ok')
+    return
+
+  assert.equal(result.report.version, '12.2.1')
+  assert.equal(result.report.url, 'https://example.com/')
+  assert.equal(result.report.device, 'mobile')
+  assert.equal(result.report.categories.performance?.score, 0.42)
+  assert.equal(result.report.categories.seo, null)
+  assert.deepEqual(result.report.performanceMetrics.map(metric => metric.name), ['LCP'])
+  assert.deepEqual(result.report.opportunities.map(audit => audit.id), ['render-blocking-resources'])
+  assert.deepEqual(result.report.passedAudits.map(audit => audit.id), ['uses-long-cache-ttl'])
+})
+
+test('reads a report that carries no audits or configSettings', () => {
+  const result = parseLighthouseReport(JSON.stringify({
+    lighthouseVersion: '12.2.1',
+    categories: { seo: { id: 'seo', title: 'SEO', score: 0.9, auditRefs: [] } },
+  }))
+
+  assert.equal(result._tag, 'Ok')
+  if (result._tag !== 'Ok')
+    return
+
+  assert.equal(result.report.device, 'desktop')
+  assert.equal(result.report.url, '')
+  assert.deepEqual(result.report.performanceMetrics, [])
+  assert.equal(result.report.categories.seo?.score, 0.9)
+})
+
+test('reads a report whose category auditRefs are missing', () => {
+  const result = parseLighthouseReport(lighthouseReport({
+    categories: { performance: { id: 'performance', title: 'Performance', score: 0.5 } },
+  }))
+
+  assert.equal(result._tag, 'Ok')
+  assert.equal(result._tag === 'Ok' && result.report.opportunities.length, 0)
+})

--- a/tests/lighthouse-report.test.ts
+++ b/tests/lighthouse-report.test.ts
@@ -112,6 +112,16 @@ test('reads a report that carries no audits or configSettings', () => {
   assert.equal(result.report.categories.seo?.score, 0.9)
 })
 
+test('keeps fetchTime null when the report has no timestamp', () => {
+  const result = parseLighthouseReport(JSON.stringify({
+    lighthouseVersion: '12',
+    categories: { seo: { id: 'seo', title: 'SEO', score: 0.9, auditRefs: [] } },
+  }))
+
+  assert.equal(result._tag, 'Ok')
+  assert.equal(result._tag === 'Ok' && result.report.fetchTime, null)
+})
+
 test('reads a report whose category auditRefs are missing', () => {
   const result = parseLighthouseReport(lighthouseReport({
     categories: { performance: { id: 'performance', title: 'Performance', score: 0.5 } },


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Sentry UNLIGHTHOUSE-C. A malformed upload to `/tools/lighthouse-report-viewer` became an unhandled error instead of the page's error banner:

```
Error: Invalid Lighthouse report format. Expected lighthouseVersion and categories.
  at a.onload (/_nuxt/D4QPALRL2.js)
```

The throw happens inside `FileReader.onload`, which runs outside the promise chain, so the `.catch()` under it never sees anything. Same shape as the HAR viewer in #17, and the parser returns its failure the same way now.

Replaying the old parser turned up a second case Sentry has not recorded yet: a report carrying `lighthouseVersion` and `categories` but no `configSettings` threw `Cannot read properties of undefined (reading 'formFactor')`. Hand-trimmed PageSpeed Insights output would do it.

`loadReport` on the composable still has no caller. Worth dropping in a follow-up?

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).