### PR TITLE
chore(routines): schedule the daily check-in

### DIFF
--- a/.github/routines.yml
+++ b/.github/routines.yml
@@ -15,3 +15,10 @@ routines:
     timezone: Australia/Sydney
     mode: propose
     enabled: true
+  - name: daily-checkin
+    on:
+      schedule:
+        - cron: '0 8 * * *'
+    timezone: Australia/Sydney
+    mode: propose
+    enabled: true


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Runs the `daily-checkin` skill on Hogwild at 08:00 Sydney, after the 07:00 Sentry check-in, so the morning report lands in a run log issue and each proposed action becomes an issue.

Wait for harlan-zw/harlan-agent-kit#156 to deploy before merging. Until then the service does not know `daily-checkin`, and a refused spec retires the Sentry check-in in this repository as well.

The check-in archives under `docs/ops/checkins/` are gitignored here, so a Hogwild run starts without a baseline until the archive gets a persistent home.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_014tmLtbNAPpmyMomBQrxyHQ