### PR TITLE
feat(daily-checkin): let DAILY_CHECKIN_DIR hold the archive outside the checkout

### DIFF
--- a/.claude/skills/daily-checkin/SKILL.md
+++ b/.claude/skills/daily-checkin/SKILL.md
@@ -7,6 +7,8 @@ description: Gather unlighthouse.dev production evidence (user feedback, tool er
 
 Produce one read-only morning report that answers two questions first: what did users tell us, and what changed that nobody asked for. Everything else is context.
 
+Archive home: every `docs/ops/checkins/` path below means `$DAILY_CHECKIN_DIR` when that variable is set. The scheduled agent runs in a disposable worktree and sets it to a persistent directory, so each morning still has yesterday's JSON and `state.json` to diff against. Write the report `.md` there too.
+
 ## Workflow
 
 1. Run `node scripts/tools/daily-checkin-data.mjs --save` from the repo root. Keep every probe error as a finding. The command archives raw evidence in `docs/ops/checkins/YYYY-MM-DD.json`; a same-day rerun writes a timestamped sibling and does not move the next baseline. Archives are gitignored because they hold user feedback text.

--- a/scripts/tools/daily-checkin-data.mjs
+++ b/scripts/tools/daily-checkin-data.mjs
@@ -13,13 +13,16 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseSentryIssuesResponse, parseWorkflowName, summarizeWorkflowRuns } from './checkin-observability.mjs'
 import { runReadOnlyProcess } from './read-only-process.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '../..')
-const checkinDir = join(root, 'docs/ops/checkins')
+// The scheduled agent runs in a disposable worktree, so its archive lives
+// outside the checkout. DAILY_CHECKIN_DIR names that home; unset means the
+// repository directory, which the desktop uses.
+const checkinDir = process.env.DAILY_CHECKIN_DIR ? resolve(process.env.DAILY_CHECKIN_DIR) : join(root, 'docs/ops/checkins')
 const statePath = join(checkinDir, 'state.json')
 const save = process.argv.includes('--save')
 const now = new Date()


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

The scheduled check-in runs in a worktree that is thrown away after the turn, and `docs/ops/checkins/` is gitignored here, so every Hogwild run starts with no prior archive and no `state.json`. With `DAILY_CHECKIN_DIR` set, the gather reads and writes its archive there instead; the site's `.env` on Hogwild points it at a persistent directory. Unset, nothing changes for the desktop.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_014tmLtbNAPpmyMomBQrxyHQ