### PR TITLE
fix(feedback): bound the stored feedback metadata

### DIFF
--- a/tests/feedback-schema.test.ts
+++ b/tests/feedback-schema.test.ts
@@ -1,0 +1,69 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { CommentFeedbackSchema, ThumbsFeedbackSchema } from '../types/schemas.ts'
+
+test('comment feedback schema truncates long metadata values instead of rejecting', () => {
+  const url = `https://example.test/?q=${'a'.repeat(301)}`
+  const parsed = CommentFeedbackSchema.safeParse({ comment: 'Great tool, thanks', context: { url } })
+
+  assert.equal(parsed.success, true)
+  assert.ok(parsed.success)
+  assert.equal(parsed.data.context?.url, url.slice(0, 300))
+})
+
+test('comment feedback schema bounds the context record', () => {
+  const comment = 'Great tool, thanks'
+
+  assert.equal(
+    CommentFeedbackSchema.safeParse({ comment, context: { url: 'https://example.test', strategy: 'mobile' } }).success,
+    true,
+  )
+  assert.equal(
+    CommentFeedbackSchema.safeParse({ comment, context: { one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9, ten: 10, eleven: 11 } }).success,
+    false,
+  )
+  const truncatedSpam = CommentFeedbackSchema.safeParse({ comment, context: { spam: 'x'.repeat(301) } })
+  assert.equal(truncatedSpam.success, true)
+  assert.ok(truncatedSpam.success)
+  assert.equal(truncatedSpam.data.context?.spam, 'x'.repeat(300))
+  assert.equal(
+    CommentFeedbackSchema.safeParse({ comment, context: { spam: { deep: 'object' } } }).success,
+    false,
+  )
+  assert.equal(
+    CommentFeedbackSchema.safeParse({ comment, context: { ['k'.repeat(41)]: 'ok' } }).success,
+    false,
+  )
+})
+
+test('comment feedback schema bounds stored metadata fields', () => {
+  const comment = 'Great tool, thanks'
+
+  assert.equal(CommentFeedbackSchema.safeParse({ comment, path: '/'.repeat(501) }).success, false)
+  assert.equal(CommentFeedbackSchema.safeParse({ comment, toolId: 't'.repeat(101) }).success, false)
+  assert.equal(CommentFeedbackSchema.safeParse({ comment, thumbFeedbackId: 'i'.repeat(101) }).success, false)
+})
+
+test('thumbs feedback schema bounds the context record', () => {
+  assert.equal(
+    ThumbsFeedbackSchema.safeParse({ thumbs: 'up', context: { url: 'https://example.test', urls: ['https://a.test', 'https://b.test'] } }).success,
+    true,
+  )
+  assert.equal(
+    ThumbsFeedbackSchema.safeParse({ thumbs: 'up', context: { urls: Array.from({ length: 21 }, (_, i) => `https://${i}.test`) } }).success,
+    false,
+  )
+  const truncatedThumbs = ThumbsFeedbackSchema.safeParse({ thumbs: 'up', context: { spam: 'y'.repeat(301) } })
+  assert.equal(truncatedThumbs.success, true)
+  assert.ok(truncatedThumbs.success)
+  assert.equal(truncatedThumbs.data.context?.spam, 'y'.repeat(300))
+  const truncatedArrayValue = ThumbsFeedbackSchema.safeParse({ thumbs: 'up', context: { urls: ['z'.repeat(301)] } })
+  assert.equal(truncatedArrayValue.success, true)
+  assert.ok(truncatedArrayValue.success)
+  assert.deepEqual(truncatedArrayValue.data.context?.urls, ['z'.repeat(300)])
+  assert.equal(
+    ThumbsFeedbackSchema.safeParse({ thumbs: 'up', context: { urls: ['https://a.test', { deep: 'object' }] } }).success,
+    false,
+  )
+})

--- a/types/schemas.ts
+++ b/types/schemas.ts
@@ -3,6 +3,40 @@ import { z } from 'zod'
 const FEEDBACK_HTML_RE = /<\/?[a-z][\s\S]*>/i
 const FEEDBACK_URL_RE = /\b(?:https?:\/\/|www\.)\S+/gi
 
+const FEEDBACK_CONTEXT_MAX_KEYS = 10
+const FEEDBACK_CONTEXT_MAX_KEY_LENGTH = 40
+const FEEDBACK_CONTEXT_MAX_VALUE_LENGTH = 300
+const FEEDBACK_CONTEXT_MAX_ARRAY_LENGTH = 20
+
+/**
+ * Tools send pasted URLs and other metadata that can legitimately exceed the
+ * stored length cap, so over-long values are truncated instead of rejected.
+ */
+function truncateContextValue(value: string): string {
+  return value.length > FEEDBACK_CONTEXT_MAX_VALUE_LENGTH
+    ? value.slice(0, FEEDBACK_CONTEXT_MAX_VALUE_LENGTH)
+    : value
+}
+
+const FeedbackContextValueSchema = z.union([
+  z.string().transform(truncateContextValue),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.union([
+    z.string().transform(truncateContextValue),
+    z.number(),
+    z.boolean(),
+    z.null(),
+  ])).max(FEEDBACK_CONTEXT_MAX_ARRAY_LENGTH),
+])
+
+const FeedbackContextSchema = z.record(z.string().max(FEEDBACK_CONTEXT_MAX_KEY_LENGTH), FeedbackContextValueSchema)
+  .refine(
+    context => Object.keys(context).length <= FEEDBACK_CONTEXT_MAX_KEYS,
+    `Must contain at most ${FEEDBACK_CONTEXT_MAX_KEYS} fields`,
+  )
+
 const FeedbackCommentSchema = z.string()
   .trim()
   .min(3, 'Must be at least 3 characters')
@@ -26,17 +60,17 @@ export interface CommentFeedbackResponse {
 
 export const ThumbsFeedbackSchema = z.object({
   thumbs: z.enum(['up', 'down']),
-  path: z.string().optional(),
-  toolId: z.string().optional(),
-  context: z.record(z.string(), z.unknown()).optional(),
+  path: z.string().max(500).optional(),
+  toolId: z.string().max(100).optional(),
+  context: FeedbackContextSchema.optional(),
 })
 
 export const CommentFeedbackSchema = z.object({
   comment: FeedbackCommentSchema,
-  path: z.string().optional(),
-  toolId: z.string().optional(),
-  thumbFeedbackId: z.string().optional(),
-  context: z.record(z.string(), z.unknown()).optional(),
+  path: z.string().max(500).optional(),
+  toolId: z.string().max(100).optional(),
+  thumbFeedbackId: z.string().max(100).optional(),
+  context: FeedbackContextSchema.optional(),
 })
 
 export type CommentFeedbackSchemaOutput = z.output<typeof CommentFeedbackSchema>


### PR DESCRIPTION
### 📚 Description

Split out of #59, which stays open for the daily rate limit.

The comment body was already capped at 1000 characters on `main`. The metadata stored beside it was not. `context` accepted `z.record(z.string(), z.unknown())`, and `path` and `toolId` accepted a string of any length. A caller could write unbounded text into the public feedback table through fields no cap covered.

This parses the metadata into a bounded shape at the boundary:

| Field | Bound |
| --- | --- |
| `context` keys | 10 |
| `context` key length | 40 |
| `context` value length | 300, truncated |
| `context` array length | 20 |
| `path` | 500 |
| `toolId` | 100 |

Tools legitimately paste long URLs, so an over-long value truncates instead of rejecting the whole submission. Nested objects are still rejected.

### Why this is separate

#59 is blocked because its daily counter is a non-atomic read-modify-write across Worker isolates, so concurrent submissions bypass the limit. That needs an atomic primitive, a Durable Object or a D1 conditional update.

None of that applies here. This change carries no counter and no shared state, so it can land while the throttle is reworked.

### ✅ Tests

`tests/feedback-schema.test.ts`, 4 tests, taken from #59 and stripped of the rate-limit setup. All pass locally.

> 🤖 AI disclosure: opened by [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit). [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01KGE9ALMX1BSCaYcLt4GzyU