### PR TITLE
fix(cloudflare): let the tracked config find the migrations

### DIFF
--- a/wrangler.local.toml
+++ b/wrangler.local.toml
@@ -17,6 +17,7 @@ id = "8f765d0c531c41edb94790f2d31d8dba"
 binding = "DB"
 database_name = "unlighthouse"
 database_id = "5274d98a-9e23-4a78-b9af-46444ec20b2a"
+migrations_dir = "server/database/migrations"
 
 [[analytics_engine_datasets]]
 binding = "TOOL_ANALYTICS"


### PR DESCRIPTION
### 📚 Description

`wrangler.toml` is gitignored (`.gitignore:22`), so `wrangler.local.toml` is the only Cloudflare config a clone gets. It set no `migrations_dir`, and wrangler does not infer one, so every `d1 migrations` command failed against the tracked config.

Before:

```
▲ WARNING  No migrations folder found. Set `migrations_dir` in your wrangler.toml file.
✘ ERROR    No migrations present at <repo>/migrations.
```

After:

```
✅ No migrations to apply!
```

### How I found it

Applying `0004_rate_limits.sql` from #59. That PR's runbook named `--config wrangler.local.toml`, which was the right config and could not work. I had to fall back to my untracked local `wrangler.toml` to apply it.

Both configs point at the same `database_id`, so the migration itself was unaffected. Anyone working from a clean clone would have hit the error with no fallback.

### ✅ Verified

Ran `wrangler d1 migrations list DB --remote --config wrangler.local.toml` before and after the change, output above. Config only, no code paths touched.

> 🤖 AI disclosure: opened by [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit). [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01KGE9ALMX1BSCaYcLt4GzyU