### PR TITLE
ci: apply D1 migrations before the deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -71,6 +71,17 @@ jobs:
           # then blamed live errors on code that was never deployed.
           SENTRY_RELEASE: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      # Schema first, so the Worker version that needs a table never activates
+      # before it exists. #59 shipped its throttle inert for this reason: the
+      # code went live and the table had to be created by hand afterwards.
+      # Migrations here are expand only, so applying them before the deploy
+      # leaves the running version working against the wider schema.
+      - name: Apply D1 migrations
+        run: pnpm exec wrangler d1 migrations apply DB --remote --config wrangler.local.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - run: pnpm deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
### 📚 Description

Nothing applied D1 migrations. A schema change reached production only if someone remembered to run wrangler by hand.

#59 is what that costs. Its feedback throttle merged, deployed, and did nothing: the code went live, `rate_limits` did not exist, every increment threw, `enforceDailyLimit` caught it and allowed the request. The limit was silently unenforced until I created the table by hand an hour later.

### Placement

```
pnpm build   →   Apply D1 migrations   →   pnpm deploy
```

- **After the build**, so a failing build migrates nothing.
- **Before the deploy**, so a Worker version never activates against a schema that has not caught up. Migrations here are expand only, so widening ahead of the deploy leaves the currently running version working.

### ✅ Verified

Ran the exact command locally against production D1:

```
$ wrangler d1 migrations apply DB --remote --config wrangler.local.toml
✅ No migrations to apply!
```

Idempotent, so a deploy with nothing pending is a no-op. The prompt takes its `yes` fallback in a non-interactive context, which is what Actions provides.

Depends on #65, already merged: `wrangler.local.toml` had no `migrations_dir`, so this command could not have worked before it.

### ⚠️ Note on scope

This applies migrations. It does not audit them. An expand-only check with protected-table rebuild detection is roadmap item 2 in `@harlan-zw/nuxt-cloudflare`, and belongs there rather than here.

> 🤖 AI disclosure: opened by [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit). [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01KGE9ALMX1BSCaYcLt4GzyU