### PR TITLE
fix(feedback): retry a transient counter failure before skipping the limit

### DIFF
--- a/server/utils/rate-limit.ts
+++ b/server/utils/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { H3Event } from 'h3'
+import { isTransientD1Error } from '@harlan-zw/nuxt-cloudflare/d1'
 import { createError, getHeader, getRequestIP, setResponseHeaders } from 'h3'
 
 interface RateLimiter {
@@ -106,6 +107,41 @@ export function getRequestIp(event: H3Event): string {
     || 'unknown'
 }
 
+/** How many times a transient failure is retried before the limit gives up. */
+const COUNT_RETRY_DELAYS_MS = [25, 75]
+
+/**
+ * Increments the counter, retrying only the failures worth retrying.
+ *
+ * A session reset or a transient D1 error is a blip, and giving up on the first
+ * one hands the caller a free request. A permanent error, a missing table for
+ * example, repeats no matter how often it is asked, so it fails fast rather
+ * than spending a round trip per attempt on every request.
+ *
+ * Returns null once the counter is judged unreachable.
+ */
+async function countRequest(store: RateLimitStore, key: string): Promise<number | null> {
+  const expiresAt = getEndOfDayTimestamp()
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await store.incrementItem(key, { expiresAt })
+    }
+    catch (error) {
+      if (!isTransientD1Error(error)) {
+        console.warn('[rate-limit] The counter failed and will not recover; allowing the request', error)
+        return null
+      }
+      const delay = COUNT_RETRY_DELAYS_MS[attempt]
+      if (delay === undefined) {
+        console.warn('[rate-limit] The counter kept failing; allowing the request', error)
+        return null
+      }
+      await new Promise(resolve => setTimeout(resolve, delay))
+    }
+  }
+}
+
 /**
  * Counts one request against a daily limit and rejects the caller past it.
  *
@@ -126,11 +162,11 @@ async function enforceDailyLimit(event: H3Event, options: {
     return
   }
 
-  const count = await store.incrementItem(key, { expiresAt: getEndOfDayTimestamp() }).catch((error) => {
-    console.warn('[rate-limit] Failed to count the request; allowing it', error)
-    return null
-  })
+  const count = await countRequest(store, key)
 
+  // A counter that cannot be reached leaves the limit unenforced for this
+  // request. That is the safer failure: a broken counter must not turn into a
+  // 429 for every visitor.
   if (count === null)
     return
 

--- a/tests/feedback-guard.test.ts
+++ b/tests/feedback-guard.test.ts
@@ -131,3 +131,61 @@ test('allows the submission when the counter fails', async () => {
 test('allows the submission when no database binding is present', async () => {
   await checkFeedbackRateLimit(fakeEvent(), null)
 })
+
+/** A store that fails the first `failures` calls with `error`, then counts normally. */
+function flakyStore(failures: number, error: unknown): RateLimitStore & { calls: () => number } {
+  let calls = 0
+  return {
+    calls: () => calls,
+    incrementItem: async () => {
+      calls++
+      if (calls <= failures)
+        throw error
+      return calls - failures
+    },
+  }
+}
+
+/** The wording D1 uses when a session is reset, which the module classifies as transient. */
+const transientError = new Error('Network connection lost.')
+
+test('retries a transient counter failure instead of skipping the limit', async () => {
+  const store = flakyStore(2, transientError)
+
+  await checkFeedbackRateLimit(fakeEvent(), store)
+
+  assert.equal(store.calls(), 3)
+})
+
+test('still enforces the limit when a retry succeeds past it', async () => {
+  let calls = 0
+  const store: RateLimitStore = {
+    incrementItem: async () => {
+      calls++
+      if (calls === 1)
+        throw transientError
+      return FEEDBACK_DAILY_LIMIT + 1
+    },
+  }
+
+  await assert.rejects(
+    () => checkFeedbackRateLimit(fakeEvent(), store),
+    (error: { statusCode?: number }) => error.statusCode === 429,
+  )
+})
+
+test('does not retry a permanent counter failure', async () => {
+  const store = flakyStore(1, new Error('no such table: rate_limits'))
+
+  await checkFeedbackRateLimit(fakeEvent(), store)
+
+  assert.equal(store.calls(), 1)
+})
+
+test('gives up once a transient failure outlasts the retries', async () => {
+  const store = flakyStore(99, transientError)
+
+  await checkFeedbackRateLimit(fakeEvent(), store)
+
+  assert.equal(store.calls(), 3)
+})


### PR DESCRIPTION
### 📚 Description

Follow-up to #59. The counter caught every failure identically and allowed the request:

```ts
const count = await store.incrementItem(...).catch(() => null)
if (count === null) return // limit not enforced
```

So one dropped D1 connection handed that caller a free submission, on a fault that would have cleared on the next attempt.

### The change

`countRequest` splits the failures by whether retrying can help, using `isTransientD1Error` from `@harlan-zw/nuxt-cloudflare/d1`:

| Failure | Behaviour |
| --- | --- |
| session reset, transient | retry at 25ms, then 75ms |
| permanent (missing table, bad SQL) | fail fast, no retry |
| transient past the retries | allow, with a reason logged |

Failing fast on permanent errors matters as much as the retry. A missing table repeats however often it is asked, so retrying it three times per request only makes an outage slower.

Allowing the request stays the last resort. A counter that is genuinely unreachable must not become a 429 for every visitor.

### ✅ Tests

Four added, 11 in the file, 126 across the suite.

- a transient failure retries and still counts (asserts 3 calls, and the run takes the expected 100ms)
- a retry that succeeds past the limit still throws 429
- a permanent failure is not retried (asserts 1 call)
- a transient failure outlasting the retries gives up and allows

The transient and permanent cases use real D1 wordings, so the classification is exercised rather than assumed.

### Note

This is the piece of `@harlan-zw/nuxt-cloudflare`'s D1 toolkit that applies today. The limiter itself is roadmap item 5 in that module, "Atomic D1 fixed-window rate limiting", and is a good extraction candidate once it has run in production for a while.

> 🤖 AI disclosure: opened by [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit). [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01KGE9ALMX1BSCaYcLt4GzyU