### PR TITLE
feat(tools): show page weight before Lighthouse finishes

### DIFF
--- a/layers/tools/app/pages/tools/page-size.vue
+++ b/layers/tools/app/pages/tools/page-size.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ComponentPublicInstance } from 'vue'
+import { createRunGate } from '~~/shared/run-gate'
 
 definePageMeta({
   breadcrumb: {
@@ -83,6 +84,7 @@ interface PageWeightResult {
   complete: boolean
   discovered: number
   measured: number
+  absent: number
 }
 
 /**
@@ -94,6 +96,12 @@ interface PageWeightResult {
  * over these panels the moment it lands.
  */
 const fastResult = ref<PageWeightResult | null>(null)
+/**
+ * One generation per analyze run. A fast pass that started for URL A must not
+ * land after the visitor has already submitted URL B, or A's breakdown would
+ * render as B's preview.
+ */
+const fastPassGate = createRunGate()
 
 const { showFloatingLoader } = useToolFloatingLoader(loading, loadingContainerRef)
 const { syncParam } = useToolUrlSync(urlInput, {
@@ -107,11 +115,13 @@ function analyze() {
     return
 
   fastResult.value = null
+  const run = fastPassGate.begin()
   $fetch<PageWeightResult>('/api/tools/page-weight', { query: { url: urlInput.value } })
     .then((weight) => {
       // A Lighthouse result that already arrived is the better answer, so a
-      // slow fast pass never replaces it.
-      if (!result.value)
+      // slow fast pass never replaces it. A run the visitor superseded is not
+      // this run, so its resolution is dropped too.
+      if (!result.value && fastPassGate.isCurrent(run))
         fastResult.value = weight
     })
     .catch((error) => {
@@ -320,7 +330,7 @@ const visualResources = computed(() => {
         </div>
 
         <p v-if="!fastResult.complete" class="text-xs text-orange-500">
-          Measured {{ fastResult.measured }} of {{ fastResult.discovered }} resources before the time budget ran out, so no total is shown yet. Lighthouse will report the full weight.
+          Measured {{ fastResult.measured }} of {{ fastResult.discovered }} resources. The rest could not be read this run, so no total is shown. Lighthouse will report the full weight.
         </p>
 
         <div v-if="fastResult.groups.length" class="space-y-2">

--- a/layers/tools/app/pages/tools/page-size.vue
+++ b/layers/tools/app/pages/tools/page-size.vue
@@ -299,7 +299,8 @@ const visualResources = computed(() => {
       <div v-if="fastResult && !result" class="p-4 sm:p-6 space-y-4">
         <div class="flex items-center gap-2 text-xs text-gray-500">
           <UIcon name="i-heroicons-bolt" class="w-4 h-4 text-green-500" />
-          <span>Read directly from the page. The full Lighthouse audit is still running.</span>
+          <span v-if="error">Read directly from the page. The full Lighthouse audit failed, so the panels it fills are unavailable.</span>
+          <span v-else>Read directly from the page. The full Lighthouse audit is still running.</span>
         </div>
 
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">

--- a/layers/tools/app/pages/tools/page-size.vue
+++ b/layers/tools/app/pages/tools/page-size.vue
@@ -74,6 +74,27 @@ interface PageSizeResult {
   screenshot: { data: string, width: number, height: number } | null
 }
 
+interface PageWeightResult {
+  fetchedUrl: string
+  totalUncompressedSize: number
+  totalRequests: number
+  groups: Array<{ type: string, count: number, size: number }>
+  largestResources: Array<{ url: string, size: number, type: string }>
+  complete: boolean
+  discovered: number
+  measured: number
+}
+
+/**
+ * The fast pass, read straight off the wire while Lighthouse runs.
+ *
+ * It answers in a second or two where the audit takes around 25, so the
+ * breakdown is on screen almost immediately. Lighthouse still owns the
+ * transfer figure, the score and everything derived from the audit, and takes
+ * over these panels the moment it lands.
+ */
+const fastResult = ref<PageWeightResult | null>(null)
+
 const { showFloatingLoader } = useToolFloatingLoader(loading, loadingContainerRef)
 const { syncParam } = useToolUrlSync(urlInput, {
   extraParams: { strategy: strategy as Ref<string> },
@@ -84,6 +105,20 @@ syncParam('strategy', strategy as Ref<string>, 'mobile')
 function analyze() {
   if (!urlInput.value.trim() || loading.value)
     return
+
+  fastResult.value = null
+  $fetch<PageWeightResult>('/api/tools/page-weight', { query: { url: urlInput.value } })
+    .then((weight) => {
+      // A Lighthouse result that already arrived is the better answer, so a
+      // slow fast pass never replaces it.
+      if (!result.value)
+        fastResult.value = weight
+    })
+    .catch((error) => {
+      // This pass only buys time. The Lighthouse run below still answers, so a
+      // failure here costs the visitor nothing but the early preview.
+      console.warn('[page-size] The fast weight pass failed; waiting on Lighthouse', error)
+    })
 
   runBg(
     () => $fetch<PageSizeResult>('/api/tools/page-size', {
@@ -242,6 +277,71 @@ const visualResources = computed(() => {
       <ToolEmptyState v-if="!result && !loading && !error" icon="i-heroicons-scale" message="Enter a URL to check page size" />
 
       <!-- Results -->
+      <!--
+        The fast pass, shown only until Lighthouse lands.
+
+        It reports uncompressed bytes, which is a different and larger number
+        than the transfer size the audit reports, so it is labelled rather than
+        presented as the same figure. A run that could not read every resource
+        shows the breakdown without a total, because a total short by half is
+        worse than waiting for the real one.
+      -->
+      <div v-if="fastResult && !result" class="p-4 sm:p-6 space-y-4">
+        <div class="flex items-center gap-2 text-xs text-gray-500">
+          <UIcon name="i-heroicons-bolt" class="w-4 h-4 text-green-500" />
+          <span>Read directly from the page. The full Lighthouse audit is still running.</span>
+        </div>
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <div v-if="fastResult.complete" class="p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 text-center">
+            <p class="text-lg font-bold" :class="getWeightColor(fastResult.totalUncompressedSize)">
+              {{ formatBytes(fastResult.totalUncompressedSize) }}
+            </p>
+            <p class="text-xs text-gray-500">
+              Uncompressed weight
+            </p>
+          </div>
+          <div class="p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 text-center">
+            <p class="text-lg font-bold text-gray-900 dark:text-white">
+              {{ fastResult.totalRequests }}
+            </p>
+            <p class="text-xs text-gray-500">
+              Requests
+            </p>
+          </div>
+          <div class="p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 text-center">
+            <p class="text-lg font-bold text-gray-900 dark:text-white">
+              {{ fastResult.groups.length }}
+            </p>
+            <p class="text-xs text-gray-500">
+              Resource types
+            </p>
+          </div>
+        </div>
+
+        <p v-if="!fastResult.complete" class="text-xs text-orange-500">
+          Measured {{ fastResult.measured }} of {{ fastResult.discovered }} resources before the time budget ran out, so no total is shown yet. Lighthouse will report the full weight.
+        </p>
+
+        <div v-if="fastResult.groups.length" class="space-y-2">
+          <div v-for="group in fastResult.groups" :key="group.type" class="flex items-center gap-3">
+            <span class="w-24 text-xs text-gray-500 capitalize">{{ group.type }}</span>
+            <div class="flex-1 h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+              <div
+                class="h-full rounded-full bg-green-500"
+                :style="{ width: `${Math.max(2, (group.size / Math.max(fastResult.groups[0]!.size, 1)) * 100)}%` }"
+              />
+            </div>
+            <span class="w-20 text-right text-xs text-gray-500">{{ formatBytes(group.size) }}</span>
+            <span class="w-10 text-right text-xs text-gray-400">{{ group.count }}</span>
+          </div>
+        </div>
+
+        <p class="text-xs text-gray-400">
+          No JavaScript runs in this pass, so anything a script loads later is not counted here.
+        </p>
+      </div>
+
       <div v-if="result" class="p-4 sm:p-6 space-y-6">
         <!-- URL info -->
         <div class="p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 flex items-center gap-2 min-w-0">

--- a/layers/tools/server/api/tools/page-weight.get.ts
+++ b/layers/tools/server/api/tools/page-weight.get.ts
@@ -67,12 +67,16 @@ async function mapWithLimit<T, R>(items: readonly T[], limit: number, work: (ite
 export default defineCachedEventHandler(async (event) => {
   await checkFreeToolRateLimit(event)
   const query = getQuery(event)
-  const validated = await validateUrl(query.url as string)
 
-  const parsed = parsePublicHttpUrl(validated)
+  // The guard runs before anything fetches. `validateUrl` probes the URL to
+  // check it is reachable, so calling it first would have this Worker request
+  // the address before the guard ever saw it, which is the request the guard
+  // exists to prevent.
+  const parsed = parsePublicHttpUrl(normalizeUrl(String(query.url ?? '')))
   if (parsed._tag === 'err')
     throw createError({ statusCode: 422, message: `Cannot measure this URL: ${parsed.reason}` })
-  const pageUrl = parsed.url.toString()
+
+  const pageUrl = (await validateUrl(parsed.url.toString())).toString()
 
   return trackToolRequest(event, { tool: 'page-size', url: pageUrl }, async () => {
     /**

--- a/layers/tools/server/api/tools/page-weight.get.ts
+++ b/layers/tools/server/api/tools/page-weight.get.ts
@@ -84,13 +84,21 @@ export default defineCachedEventHandler(async (event) => {
      * submitted URL. The platform's `follow` mode would bounce this site's
      * fetch at an internal address a hostile page named, no questions asked.
      */
+    // The deadline covers the document too. It used to start after the page had
+    // loaded, so a slow page plus its redirect hops could run for a minute on an
+    // endpoint whose whole purpose is to answer before Lighthouse does.
+    const deadline = Date.now() + TOTAL_BUDGET_MS
+    const documentBudget = () => Math.min(DOCUMENT_TIMEOUT_MS, deadline - Date.now())
+
     let landed: { response: Response, url: string } | null = null
     let target = pageUrl
     for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+      if (documentBudget() <= 0)
+        break
       const response = await fetch(target, {
         headers: { 'user-agent': USER_AGENT },
         redirect: 'manual',
-        signal: AbortSignal.timeout(DOCUMENT_TIMEOUT_MS),
+        signal: AbortSignal.timeout(documentBudget()),
       }).catch(() => {
         // The reason the page did not load is upstream detail, and forwarding it
         // would put the visitor's URL into this site's error text. The 502 below
@@ -128,7 +136,6 @@ export default defineCachedEventHandler(async (event) => {
     const refs = extractResourceRefs(html, finalUrl)
     const attempted = refs.slice(0, RESOURCE_LIMIT)
 
-    const deadline = Date.now() + TOTAL_BUDGET_MS
     const outcomes = await mapWithLimit(attempted, CONCURRENCY, async (ref): Promise<SubresourceOutcome> => {
       const result = await measureResource(ref.url, {
         deadline,

--- a/layers/tools/server/api/tools/page-weight.get.ts
+++ b/layers/tools/server/api/tools/page-weight.get.ts
@@ -4,9 +4,11 @@ import {
   classifyResource,
   extractResourceRefs,
   MAX_BODY_BYTES,
+  MAX_REDIRECT_HOPS,
   measureResource,
   parsePublicHttpUrl,
   readBodyCapped,
+  redirectHop,
   RESOURCE_LIMIT,
   summarizeWeight,
 } from '~~/shared/page-weight'
@@ -73,22 +75,43 @@ export default defineCachedEventHandler(async (event) => {
   const pageUrl = parsed.url.toString()
 
   return trackToolRequest(event, { tool: 'page-size', url: pageUrl }, async () => {
-    const document = await fetch(pageUrl, {
-      headers: { 'user-agent': USER_AGENT },
-      redirect: 'follow',
-      signal: AbortSignal.timeout(DOCUMENT_TIMEOUT_MS),
-    }).catch(() => {
-      // The reason the page did not load is upstream detail, and forwarding it
-      // would put the visitor's URL into this site's error text. The 502 below
-      // is the whole answer.
-      return null
-    })
+    /**
+     * Redirects are followed by hand so every hop passes the same guard as the
+     * submitted URL. The platform's `follow` mode would bounce this site's
+     * fetch at an internal address a hostile page named, no questions asked.
+     */
+    let landed: { response: Response, url: string } | null = null
+    let target = pageUrl
+    for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+      const response = await fetch(target, {
+        headers: { 'user-agent': USER_AGENT },
+        redirect: 'manual',
+        signal: AbortSignal.timeout(DOCUMENT_TIMEOUT_MS),
+      }).catch(() => {
+        // The reason the page did not load is upstream detail, and forwarding it
+        // would put the visitor's URL into this site's error text. The 502 below
+        // is the whole answer.
+        return null
+      })
+      if (!response)
+        break
 
-    if (!document || !document.ok)
+      const next = redirectHop(response, target)
+      if (next._tag === 'not-redirect') {
+        landed = { response, url: target }
+        break
+      }
+      // A hop the guard refuses is a page this tool will not read.
+      if (next._tag === 'blocked')
+        break
+      target = next.url
+    }
+
+    if (!landed || !landed.response.ok)
       throw createError({ statusCode: 502, message: 'Could not load the page' })
 
-    const finalUrl = document.url || pageUrl
-    const body = await readBodyCapped(document, MAX_BODY_BYTES)
+    const finalUrl = landed.url
+    const body = await readBodyCapped(landed.response, MAX_BODY_BYTES)
     if (body._tag === 'over-cap')
       throw createError({ statusCode: 413, message: 'This page is too large for the fast measurement' })
     const html = new TextDecoder().decode(body.bytes)

--- a/layers/tools/server/api/tools/page-weight.get.ts
+++ b/layers/tools/server/api/tools/page-weight.get.ts
@@ -1,8 +1,13 @@
 import type { WeightEntry } from '~~/shared/page-weight'
 import {
+  assessCompleteness,
   classifyResource,
   extractResourceRefs,
+  MAX_BODY_BYTES,
+  measureResource,
   parsePublicHttpUrl,
+  readBodyCapped,
+  RESOURCE_LIMIT,
   summarizeWeight,
 } from '~~/shared/page-weight'
 
@@ -20,8 +25,6 @@ import {
  * it, because a number presented as the whole truth would be wrong.
  */
 
-/** Nothing is fetched past this, so one enormous page cannot hold a Worker open. */
-const RESOURCE_LIMIT = 120
 /** Requests in flight at once. High enough to stay fast, low enough to not look like an attack. */
 const CONCURRENCY = 16
 const DOCUMENT_TIMEOUT_MS = 10_000
@@ -37,98 +40,10 @@ const TOTAL_BUDGET_MS = 8_000
 /** A browser identifies itself, and plenty of servers vary their response when a client does not. */
 const USER_AGENT = 'Mozilla/5.0 (compatible; UnlighthouseBot/1.0; +https://unlighthouse.dev/tools/page-size)'
 
-/**
- * Reads a size out of response headers without downloading anything.
- *
- * `Content-Range` carries the full length even on a one-byte request, and
- * `Content-Length` answers on a HEAD that bothers to send it. A compressed
- * chunked response sends neither, which is why a download is still the last
- * resort.
- */
-function sizeFromHeaders(response: Response | null): { size: number, contentType: string | null } | null {
-  if (!response)
-    return null
-
-  const contentRange = response.headers.get('content-range')
-  const total = contentRange ? Number(contentRange.split('/')[1]) : Number.NaN
-  if (Number.isFinite(total) && total > 0)
-    return { size: total, contentType: response.headers.get('content-type') }
-
-  if (!response.ok)
-    return null
-
-  const declared = Number(response.headers.get('content-length'))
-  // A one-byte length is the range response itself, not the resource.
-  if (Number.isFinite(declared) && declared > 1)
-    return { size: declared, contentType: response.headers.get('content-type') }
-
-  return null
-}
-
-/**
- * Measures one resource, spending as little as the server allows.
- *
- * Servers disagree about which cheap probe they answer. Cloudflare in front of
- * this site answers HEAD with a length; nuxt.com answers HEAD with no length at
- * all but serves ranges. Trying both before downloading turns most resources
- * into one small round trip instead of a full transfer.
- *
- * Every path reports the identity length, so these are uncompressed bytes. The
- * response labels them that way, because the transfer figure Lighthouse reports
- * is a different, smaller number.
- */
-async function measure(url: string, deadline: number): Promise<{ size: number, contentType: string | null } | null> {
-  const budget = () => Math.min(RESOURCE_TIMEOUT_MS, deadline - Date.now())
-
-  const probes: RequestInit[] = [
-    { method: 'HEAD' },
-    { headers: { range: 'bytes=0-0' } },
-  ]
-
-  for (const probe of probes) {
-    if (budget() <= 0)
-      return null
-
-    const response = await fetch(url, {
-      ...probe,
-      headers: { 'user-agent': USER_AGENT, ...(probe.headers as Record<string, string> | undefined) },
-      redirect: 'follow',
-      signal: AbortSignal.timeout(budget()),
-    }).catch(() => {
-      // A subresource that refuses, times out, or blocks this fetch is a normal
-      // result for a page on the open web, not a fault in this tool. It is
-      // reported as unmeasured through `complete` rather than failing the run.
-      return null
-    })
-
-    const sized = sizeFromHeaders(response)
-    if (sized)
-      return sized
-  }
-
-  if (budget() <= 0)
-    return null
-
-  const response = await fetch(url, {
-    headers: { 'user-agent': USER_AGENT },
-    redirect: 'follow',
-    signal: AbortSignal.timeout(budget()),
-  }).catch(() => {
-    // Same as above: an unreachable resource is counted as unmeasured.
-    return null
-  })
-
-  if (!response || !response.ok)
-    return null
-
-  const body = await response.arrayBuffer().catch(() => {
-    // A body that stops mid-stream leaves no length to report, so the resource
-    // is counted as unmeasured rather than guessed at.
-    return null
-  })
-
-  return body ? { size: body.byteLength, contentType: response.headers.get('content-type') } : null
-}
+type SubresourceOutcome
+  = | { _tag: 'measured', entry: WeightEntry }
+    | { _tag: 'absent' }
+    | { _tag: 'unmeasured' }
 
 /** Runs `work` over `items`, never more than `limit` at a time. */
 async function mapWithLimit<T, R>(items: readonly T[], limit: number, work: (item: T) => Promise<R>): Promise<R[]> {
@@ -173,32 +88,56 @@ export default defineCachedEventHandler(async (event) => {
       throw createError({ statusCode: 502, message: 'Could not load the page' })
 
     const finalUrl = document.url || pageUrl
-    const html = await document.text()
+    const body = await readBodyCapped(document, MAX_BODY_BYTES)
+    if (body._tag === 'over-cap')
+      throw createError({ statusCode: 413, message: 'This page is too large for the fast measurement' })
+    const html = new TextDecoder().decode(body.bytes)
     const documentEntry: WeightEntry = {
       url: finalUrl,
       type: 'document',
-      size: new TextEncoder().encode(html).byteLength,
+      size: body.bytes.byteLength,
     }
 
     const refs = extractResourceRefs(html, finalUrl)
-    const measured = refs.slice(0, RESOURCE_LIMIT)
+    const attempted = refs.slice(0, RESOURCE_LIMIT)
 
     const deadline = Date.now() + TOTAL_BUDGET_MS
-    const entries = await mapWithLimit(measured, CONCURRENCY, async (ref): Promise<WeightEntry | null> => {
-      const result = await measure(ref.url, deadline)
-      if (!result)
-        return null
+    const outcomes = await mapWithLimit(attempted, CONCURRENCY, async (ref): Promise<SubresourceOutcome> => {
+      const result = await measureResource(ref.url, {
+        deadline,
+        timeoutMs: RESOURCE_TIMEOUT_MS,
+        maxBodyBytes: MAX_BODY_BYTES,
+        userAgent: USER_AGENT,
+      })
+      if (result._tag !== 'measured')
+        return result
       return {
-        url: ref.url,
-        // The server's own answer beats the guess made from the tag.
-        type: classifyResource(ref.url, result.contentType) === 'other' ? ref.type : classifyResource(ref.url, result.contentType),
-        size: result.size,
+        _tag: 'measured',
+        entry: {
+          url: ref.url,
+          // The server's own answer beats the guess made from the tag.
+          type: classifyResource(ref.url, result.contentType) === 'other' ? ref.type : classifyResource(ref.url, result.contentType),
+          size: result.size,
+        },
       }
     })
 
-    const found = entries.filter((entry): entry is WeightEntry => entry !== null)
+    const found: WeightEntry[] = []
+    let absent = 0
+    let unmeasured = 0
+    for (const outcome of outcomes) {
+      if (outcome._tag === 'measured')
+        found.push(outcome.entry)
+      else if (outcome._tag === 'absent')
+        absent++
+      else
+        unmeasured++
+    }
+
+    // Any unmeasured resource means the run stopped early, whether the clock
+    // or the byte cap stopped it. An absent resource means no such thing.
+    const assessment = assessCompleteness(refs.length, attempted.length, found.length, unmeasured > 0)
     const { totalSize, totalRequests, groups, largestResources } = summarizeWeight([documentEntry, ...found])
-    const complete = refs.length <= RESOURCE_LIMIT && found.length === measured.length
 
     return {
       url: pageUrl,
@@ -217,21 +156,29 @@ export default defineCachedEventHandler(async (event) => {
       groups,
       largestResources,
       /**
-       * False when a resource went unmeasured, so nothing downstream presents a
-       * partial total as the page weight. A page that is slow or hostile to
-       * range requests can exhaust the budget with most of itself unread, and a
-       * total that is short by half is worse than no total at all.
+       * False when the run stopped early, so nothing downstream presents a
+       * partial total as the page weight. A resource that answered 404 is not
+       * a stop: it is counted in `absent` and the total stands. A page that is
+       * slow, hostile to range requests, or past the resource limit leaves
+       * part of itself unread, and a total that is short by half is worse
+       * than no total at all.
        */
-      complete,
+      complete: assessment.complete,
       discovered: refs.length,
       measured: found.length,
-      skipped: Math.max(0, refs.length - measured.length),
+      /**
+       * Resources that answered with an error after every probe (404, 401,
+       * refused). They contribute no bytes. Absent is a fact about the page,
+       * not about this run.
+       */
+      absent,
+      skipped: assessment.skipped,
     }
   })
 }, {
   base: 'psi',
   swr: true,
-  getKey: event => `page-weight:v1:${getQuery(event).url}`,
+  getKey: event => `page-weight:v2:${getQuery(event).url}`,
   maxAge: 60 * 60,
   staleMaxAge: 24 * 60 * 60,
 })

--- a/layers/tools/server/api/tools/page-weight.get.ts
+++ b/layers/tools/server/api/tools/page-weight.get.ts
@@ -1,0 +1,237 @@
+import type { WeightEntry } from '~~/shared/page-weight'
+import {
+  classifyResource,
+  extractResourceRefs,
+  parsePublicHttpUrl,
+  summarizeWeight,
+} from '~~/shared/page-weight'
+
+/**
+ * The fast half of the page size tool.
+ *
+ * `page-size` reads its numbers from a PageSpeed Insights Lighthouse run, which
+ * takes around 25 seconds. A visitor reported that wait as too slow, and page
+ * weight does not need Lighthouse: the bytes are on the wire. This reads them
+ * directly so the breakdown appears while Lighthouse is still running, and
+ * `page-size` fills in the audit-derived panels behind it.
+ *
+ * The total is a floor. No JavaScript runs here, so a resource a script fetches
+ * later is not counted. The response says so in `complete`, and the UI repeats
+ * it, because a number presented as the whole truth would be wrong.
+ */
+
+/** Nothing is fetched past this, so one enormous page cannot hold a Worker open. */
+const RESOURCE_LIMIT = 120
+/** Requests in flight at once. High enough to stay fast, low enough to not look like an attack. */
+const CONCURRENCY = 16
+const DOCUMENT_TIMEOUT_MS = 10_000
+const RESOURCE_TIMEOUT_MS = 5_000
+/**
+ * The whole measurement stops here.
+ *
+ * The point of this endpoint is a number that arrives before Lighthouse does,
+ * so it is bounded by design rather than by how well a site behaves. A run that
+ * runs out reports what it measured and says it is incomplete.
+ */
+const TOTAL_BUDGET_MS = 8_000
+/** A browser identifies itself, and plenty of servers vary their response when a client does not. */
+const USER_AGENT = 'Mozilla/5.0 (compatible; UnlighthouseBot/1.0; +https://unlighthouse.dev/tools/page-size)'
+
+/**
+ * Reads a size out of response headers without downloading anything.
+ *
+ * `Content-Range` carries the full length even on a one-byte request, and
+ * `Content-Length` answers on a HEAD that bothers to send it. A compressed
+ * chunked response sends neither, which is why a download is still the last
+ * resort.
+ */
+function sizeFromHeaders(response: Response | null): { size: number, contentType: string | null } | null {
+  if (!response)
+    return null
+
+  const contentRange = response.headers.get('content-range')
+  const total = contentRange ? Number(contentRange.split('/')[1]) : Number.NaN
+  if (Number.isFinite(total) && total > 0)
+    return { size: total, contentType: response.headers.get('content-type') }
+
+  if (!response.ok)
+    return null
+
+  const declared = Number(response.headers.get('content-length'))
+  // A one-byte length is the range response itself, not the resource.
+  if (Number.isFinite(declared) && declared > 1)
+    return { size: declared, contentType: response.headers.get('content-type') }
+
+  return null
+}
+
+/**
+ * Measures one resource, spending as little as the server allows.
+ *
+ * Servers disagree about which cheap probe they answer. Cloudflare in front of
+ * this site answers HEAD with a length; nuxt.com answers HEAD with no length at
+ * all but serves ranges. Trying both before downloading turns most resources
+ * into one small round trip instead of a full transfer.
+ *
+ * Every path reports the identity length, so these are uncompressed bytes. The
+ * response labels them that way, because the transfer figure Lighthouse reports
+ * is a different, smaller number.
+ */
+async function measure(url: string, deadline: number): Promise<{ size: number, contentType: string | null } | null> {
+  const budget = () => Math.min(RESOURCE_TIMEOUT_MS, deadline - Date.now())
+
+  const probes: RequestInit[] = [
+    { method: 'HEAD' },
+    { headers: { range: 'bytes=0-0' } },
+  ]
+
+  for (const probe of probes) {
+    if (budget() <= 0)
+      return null
+
+    const response = await fetch(url, {
+      ...probe,
+      headers: { 'user-agent': USER_AGENT, ...(probe.headers as Record<string, string> | undefined) },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(budget()),
+    }).catch(() => {
+      // A subresource that refuses, times out, or blocks this fetch is a normal
+      // result for a page on the open web, not a fault in this tool. It is
+      // reported as unmeasured through `complete` rather than failing the run.
+      return null
+    })
+
+    const sized = sizeFromHeaders(response)
+    if (sized)
+      return sized
+  }
+
+  if (budget() <= 0)
+    return null
+
+  const response = await fetch(url, {
+    headers: { 'user-agent': USER_AGENT },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(budget()),
+  }).catch(() => {
+    // Same as above: an unreachable resource is counted as unmeasured.
+    return null
+  })
+
+  if (!response || !response.ok)
+    return null
+
+  const body = await response.arrayBuffer().catch(() => {
+    // A body that stops mid-stream leaves no length to report, so the resource
+    // is counted as unmeasured rather than guessed at.
+    return null
+  })
+
+  return body ? { size: body.byteLength, contentType: response.headers.get('content-type') } : null
+}
+
+/** Runs `work` over `items`, never more than `limit` at a time. */
+async function mapWithLimit<T, R>(items: readonly T[], limit: number, work: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = Array.from({ length: items.length })
+  let next = 0
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const index = next++
+      if (index >= items.length)
+        return
+      results[index] = await work(items[index]!)
+    }
+  }))
+
+  return results
+}
+
+export default defineCachedEventHandler(async (event) => {
+  await checkFreeToolRateLimit(event)
+  const query = getQuery(event)
+  const validated = await validateUrl(query.url as string)
+
+  const parsed = parsePublicHttpUrl(validated)
+  if (parsed._tag === 'err')
+    throw createError({ statusCode: 422, message: `Cannot measure this URL: ${parsed.reason}` })
+  const pageUrl = parsed.url.toString()
+
+  return trackToolRequest(event, { tool: 'page-size', url: pageUrl }, async () => {
+    const document = await fetch(pageUrl, {
+      headers: { 'user-agent': USER_AGENT },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(DOCUMENT_TIMEOUT_MS),
+    }).catch(() => {
+      // The reason the page did not load is upstream detail, and forwarding it
+      // would put the visitor's URL into this site's error text. The 502 below
+      // is the whole answer.
+      return null
+    })
+
+    if (!document || !document.ok)
+      throw createError({ statusCode: 502, message: 'Could not load the page' })
+
+    const finalUrl = document.url || pageUrl
+    const html = await document.text()
+    const documentEntry: WeightEntry = {
+      url: finalUrl,
+      type: 'document',
+      size: new TextEncoder().encode(html).byteLength,
+    }
+
+    const refs = extractResourceRefs(html, finalUrl)
+    const measured = refs.slice(0, RESOURCE_LIMIT)
+
+    const deadline = Date.now() + TOTAL_BUDGET_MS
+    const entries = await mapWithLimit(measured, CONCURRENCY, async (ref): Promise<WeightEntry | null> => {
+      const result = await measure(ref.url, deadline)
+      if (!result)
+        return null
+      return {
+        url: ref.url,
+        // The server's own answer beats the guess made from the tag.
+        type: classifyResource(ref.url, result.contentType) === 'other' ? ref.type : classifyResource(ref.url, result.contentType),
+        size: result.size,
+      }
+    })
+
+    const found = entries.filter((entry): entry is WeightEntry => entry !== null)
+    const { totalSize, totalRequests, groups, largestResources } = summarizeWeight([documentEntry, ...found])
+    const complete = refs.length <= RESOURCE_LIMIT && found.length === measured.length
+
+    return {
+      url: pageUrl,
+      fetchedUrl: finalUrl,
+      timestamp: Date.now(),
+      /**
+       * Uncompressed bytes, not transfer bytes.
+       *
+       * Every size here is the resource's identity length, which is what a
+       * range or a length header reports and what a decoded download measures.
+       * The transfer figure is smaller and comes from Lighthouse, so the two
+       * are shown as the separate numbers they are.
+       */
+      totalUncompressedSize: totalSize,
+      totalRequests,
+      groups,
+      largestResources,
+      /**
+       * False when a resource went unmeasured, so nothing downstream presents a
+       * partial total as the page weight. A page that is slow or hostile to
+       * range requests can exhaust the budget with most of itself unread, and a
+       * total that is short by half is worse than no total at all.
+       */
+      complete,
+      discovered: refs.length,
+      measured: found.length,
+      skipped: Math.max(0, refs.length - measured.length),
+    }
+  })
+}, {
+  base: 'psi',
+  swr: true,
+  getKey: event => `page-weight:v1:${getQuery(event).url}`,
+  maxAge: 60 * 60,
+  staleMaxAge: 24 * 60 * 60,
+})

--- a/layers/tools/server/api/tools/page-weight.get.ts
+++ b/layers/tools/server/api/tools/page-weight.get.ts
@@ -123,7 +123,14 @@ export default defineCachedEventHandler(async (event) => {
       throw createError({ statusCode: 502, message: 'Could not load the page' })
 
     const finalUrl = landed.url
-    const body = await readBodyCapped(landed.response, MAX_BODY_BYTES)
+    const body = await readBodyCapped(landed.response, MAX_BODY_BYTES).catch(() => {
+      // A body that dies mid-stream leaves nothing to decode, and why it died
+      // is upstream detail, the same as a document fetch that never landed.
+      // The 502 below is the whole answer.
+      return null
+    })
+    if (!body)
+      throw createError({ statusCode: 502, message: 'Could not load the page' })
     if (body._tag === 'over-cap')
       throw createError({ statusCode: 413, message: 'This page is too large for the fast measurement' })
     const html = new TextDecoder().decode(body.bytes)

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -200,16 +200,62 @@ export function classifyResource(url: string, contentType?: string | null): Reso
 }
 
 /**
+ * The named character references markup can carry in an attribute value.
+ *
+ * HTML decodes these before a browser fetches, so this reads the value the way
+ * the browser would. Numeric references (`&#38;`, `&#x26;`) cover the rest.
+ */
+const NAMED_CHARACTER_REFERENCES: Record<string, string> = {
+  amp: '&',
+  AMP: '&',
+  lt: '<',
+  LT: '<',
+  gt: '>',
+  GT: '>',
+  quot: '"',
+  QUOT: '"',
+  apos: '\'',
+  nbsp: '\u00A0',
+  NBSP: '\u00A0',
+}
+
+/** The character HTML substitutes for a reference that names nothing valid. */
+const INVALID_CHARACTER_REFERENCE = '\uFFFD'
+
+function codePointToCharacter(code: number): string {
+  // HTML maps NUL, surrogates, and anything past the Unicode range to U+FFFD.
+  if (code <= 0 || code > 0x10FFFF || (code >= 0xD800 && code <= 0xDFFF))
+    return INVALID_CHARACTER_REFERENCE
+  return String.fromCodePoint(code)
+}
+
+function decodeCharacterReferences(value: string): string {
+  return value.replace(
+    /&(?:#(\d+)|#x([0-9a-f]+)|([a-z][a-z0-9]*));/gi,
+    (whole, decimal: string | undefined, hexadecimal: string | undefined, name: string | undefined) => {
+      if (decimal !== undefined)
+        return codePointToCharacter(Number(decimal))
+      if (hexadecimal !== undefined)
+        return codePointToCharacter(Number.parseInt(hexadecimal, 16))
+      return NAMED_CHARACTER_REFERENCES[name!] ?? whole
+    },
+  )
+}
+
+/**
  * Pulls one attribute out of a tag's attribute text.
  *
  * The name is anchored on the left, since `\b` holds between `-` and a letter
- * and would read `data-src` as `src`.
+ * and would read `data-src` as `src`. The captured value is decoded, because
+ * the browser fetches `/px?a=1&b=2` when the markup says `&amp;`, and the
+ * encoded spelling would otherwise dodge the seen-dedupe.
  */
 function attribute(tag: string, name: string): string | null {
   const match = tag.match(new RegExp(`(?<![\\w-])${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i'))
   if (!match)
     return null
-  return match[1] ?? match[2] ?? match[3] ?? null
+  const value = match[1] ?? match[2] ?? match[3]
+  return value === undefined ? null : decodeCharacterReferences(value)
 }
 
 /** The first candidate in a `srcset`, which is the one a plain reader would take. */

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -270,6 +270,9 @@ const RAW_TEXT_ELEMENTS = new Set(['script', 'style', 'textarea', 'title'])
 /** The elements that can name a subresource. */
 const RESOURCE_ELEMENTS = new Set(['script', 'link', 'img', 'source', 'video', 'audio', 'iframe', 'embed', 'object', 'track'])
 
+/** The single element that can change how relative references resolve. */
+const BASE_ELEMENT = new Set(['base'])
+
 interface ScannedTag {
   name: string
   attrs: string
@@ -284,7 +287,8 @@ interface ScannedTag {
  * has to skip comments and the contents of script and style, or a tag written
  * inside either is counted as a resource the page never requests.
  */
-function* scanTags(html: string): Generator<ScannedTag> {
+function* scanTags(html: string, options: { include?: Set<string> } = {}): Generator<ScannedTag> {
+  const include = options.include ?? RESOURCE_ELEMENTS
   let index = 0
 
   while (index < html.length) {
@@ -330,7 +334,7 @@ function* scanTags(html: string): Generator<ScannedTag> {
     const attrs = html.slice(open + nameMatch[0].length, cursor)
     const selfClosing = attrs.trimEnd().endsWith('/')
 
-    if (RESOURCE_ELEMENTS.has(name))
+    if (include.has(name))
       yield { name, attrs }
 
     index = cursor + 1
@@ -347,15 +351,37 @@ function* scanTags(html: string): Generator<ScannedTag> {
 }
 
 /**
+ * The URL relative references resolve against.
+ *
+ * `<base href>` changes that for the whole document, so reading it is the
+ * difference between fetching a page's real assets and fetching paths that do
+ * not exist. Only the first `base` counts, which is what a browser does, and a
+ * value that is not a public http URL is ignored rather than trusted.
+ */
+export function resolveDocumentBase(html: string, documentUrl: string): string {
+  for (const { name, attrs } of scanTags(html, { include: BASE_ELEMENT })) {
+    if (name !== 'base')
+      continue
+    const href = attribute(attrs, 'href')
+    if (!href)
+      continue
+    const parsed = parsePublicHttpUrl(href.trim(), documentUrl)
+    return parsed._tag === 'ok' ? parsed.url.toString() : documentUrl
+  }
+  return documentUrl
+}
+
+/**
  * Reads every subresource the served HTML asks for.
  *
  * Duplicates collapse, because a browser fetches one URL once however many
  * tags name it. Anything that is not a public http URL is dropped here rather
  * than at fetch time, so one rule decides what this tool will request.
  */
-export function extractResourceRefs(html: string, baseUrl: string): ResourceRef[] {
+export function extractResourceRefs(html: string, documentUrl: string): ResourceRef[] {
   const seen = new Set<string>()
   const refs: ResourceRef[] = []
+  const baseUrl = resolveDocumentBase(html, documentUrl)
 
   for (const { name: tag, attrs } of scanTags(html)) {
     let raw: string | null = null
@@ -544,6 +570,19 @@ export interface MeasureResourceOptions {
 }
 
 /**
+ * True when a status means the resource is not there, rather than not readable.
+ *
+ * Only a definitive answer is a fact about the page. A 401 or 403 is usually
+ * this tool being refused rather than the file being missing, a 429 is the
+ * server asking it to slow down, and a 5xx is the server having a bad moment.
+ * Counting any of those as absent would drop real bytes from a total that
+ * still called itself complete.
+ */
+export function isResourceGone(status: number): boolean {
+  return status === 404 || status === 410
+}
+
+/**
  * Reads a size out of response headers without downloading anything.
  *
  * `Content-Range` carries the full length even on a one-byte request, and
@@ -660,7 +699,7 @@ export async function measureResource(url: string, options: MeasureResourceOptio
     return response
 
   if (!response.ok)
-    return { _tag: 'absent' }
+    return { _tag: isResourceGone(response.status) ? 'absent' : 'unmeasured' }
 
   const body = await readBodyCapped(response, options.maxBodyBytes).catch(() => {
     // A body that stops mid-stream leaves no length to report, so the

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -279,6 +279,28 @@ interface ScannedTag {
 }
 
 /**
+ * Case-insensitive matchers for each raw text element's closing tag, one per
+ * element name, searched forward from an offset in place.
+ *
+ * Searching a lowercased copy of the document instead would pay a full extra
+ * document pass per script, style, or title element, and an offset read off
+ * the copy points into the original at the wrong place whenever lowercasing
+ * changes a character's length. Element names are `[a-z0-9-]`, so the pattern
+ * holds no metacharacters. The scan is synchronous, so sharing one matcher
+ * per name and setting `lastIndex` before each search is safe.
+ */
+const CLOSING_TAG_PATTERNS = new Map<string, RegExp>()
+
+function closingTagPattern(name: string): RegExp {
+  let pattern = CLOSING_TAG_PATTERNS.get(name)
+  if (!pattern) {
+    pattern = new RegExp(`</${name}`, 'gi')
+    CLOSING_TAG_PATTERNS.set(name, pattern)
+  }
+  return pattern
+}
+
+/**
  * Walks the HTML and yields each resource tag with its attribute text.
  *
  * A regex cannot do this. `<[^>]*>` ends the tag at the first `>`, and a `>`
@@ -342,10 +364,12 @@ function* scanTags(html: string, options: { include?: Set<string> } = {}): Gener
     // Everything inside a raw text element is text. Skipping it stops a tag
     // written in a string or a stylesheet from being read as markup.
     if (RAW_TEXT_ELEMENTS.has(name) && !selfClosing) {
-      const closing = html.toLowerCase().indexOf(`</${name}`, index)
-      if (closing === -1)
+      const pattern = closingTagPattern(name)
+      pattern.lastIndex = index
+      const closing = pattern.exec(html)
+      if (!closing)
         return
-      index = closing + name.length + 2
+      index = closing.index + name.length + 2
     }
   }
 }

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -268,7 +268,7 @@ function firstSrcsetCandidate(srcset: string): string | null {
 const RAW_TEXT_ELEMENTS = new Set(['script', 'style', 'textarea', 'title'])
 
 /** The elements that can name a subresource. */
-const RESOURCE_ELEMENTS = new Set(['script', 'link', 'img', 'source', 'video', 'audio'])
+const RESOURCE_ELEMENTS = new Set(['script', 'link', 'img', 'source', 'video', 'audio', 'iframe', 'embed', 'object', 'track'])
 
 interface ScannedTag {
   name: string
@@ -388,9 +388,37 @@ export function extractResourceRefs(html: string, baseUrl: string): ResourceRef[
       raw = (srcset ? firstSrcsetCandidate(srcset) : null) || attribute(attrs, 'src')
       hinted = tag === 'img' ? 'image' : null
     }
+    else if (tag === 'object') {
+      // `object` names its resource with `data`, not `src`.
+      raw = attribute(attrs, 'data')
+      hinted = null
+    }
+    else if (tag === 'iframe' || tag === 'embed') {
+      raw = attribute(attrs, 'src')
+      hinted = null
+    }
+    else if (tag === 'track') {
+      raw = attribute(attrs, 'src')
+      hinted = 'other'
+    }
     else {
       raw = attribute(attrs, 'src')
       hinted = 'media'
+    }
+
+    // A poster loads with the media element, so it counts as its own resource.
+    if (tag === 'video' || tag === 'audio') {
+      const poster = attribute(attrs, 'poster')
+      if (poster) {
+        const parsedPoster = parsePublicHttpUrl(poster.trim(), baseUrl)
+        if (parsedPoster._tag === 'ok') {
+          const posterHref = parsedPoster.url.toString()
+          if (!seen.has(posterHref)) {
+            seen.add(posterHref)
+            refs.push({ url: posterHref, type: 'image' })
+          }
+        }
+      }
     }
 
     if (!raw)

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -1,0 +1,242 @@
+/**
+ * The pure half of the fast page weight measurement.
+ *
+ * The tool used to get every number from a PageSpeed Insights Lighthouse run,
+ * which takes around 25 seconds. This module reads the same page directly, so
+ * the weight and the resource breakdown can be shown while Lighthouse is still
+ * running. It performs no IO, so every rule here is testable on its own.
+ *
+ * What it cannot see: this reads the HTML the server sent. It runs no
+ * JavaScript, so a resource a script fetches later is not counted. The total is
+ * a floor, not the full picture, and the UI says so.
+ */
+
+/** The resource kinds the breakdown reports, matching Lighthouse's own grouping. */
+export type ResourceType = 'document' | 'script' | 'stylesheet' | 'image' | 'font' | 'media' | 'other'
+
+export interface ResourceRef {
+  url: string
+  type: ResourceType
+}
+
+export type UrlParse
+  = | { _tag: 'ok', url: URL }
+    | { _tag: 'err', reason: string }
+
+/**
+ * Hosts a measurement must never fetch.
+ *
+ * Lighthouse ran on Google's infrastructure, so a hostile URL reached Google
+ * rather than this Worker. Reading the page here makes that this site's
+ * request, so a literal address pointing back inside a network is refused
+ * before any fetch. Names are not resolved here, so this stops literals only;
+ * the platform is what stops a name that resolves inward.
+ */
+const BLOCKED_HOST_PATTERNS: RegExp[] = [
+  /^localhost$/i,
+  /\.localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(?:1[6-9]|2\d|3[01])\./,
+  /^169\.254\./,
+  /^0\./,
+  /^\[?::1\]?$/,
+  /^\[?f[cd][0-9a-f]{2}:/i,
+  /^\[?fe80:/i,
+]
+
+/**
+ * Parses one URL into something safe to fetch, or says why it is not.
+ *
+ * Every URL the measurement touches passes through here once, including the
+ * ones read out of the fetched HTML, which the page author controls.
+ */
+export function parsePublicHttpUrl(raw: string, base?: string): UrlParse {
+  let url: URL
+  try {
+    url = base ? new URL(raw, base) : new URL(raw)
+  }
+  catch {
+    return { _tag: 'err', reason: 'not a URL' }
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:')
+    return { _tag: 'err', reason: `unsupported scheme ${url.protocol}` }
+
+  if (!url.hostname)
+    return { _tag: 'err', reason: 'no host' }
+
+  if (BLOCKED_HOST_PATTERNS.some(pattern => pattern.test(url.hostname)))
+    return { _tag: 'err', reason: 'host is not public' }
+
+  return { _tag: 'ok', url }
+}
+
+const EXTENSION_TYPES: Array<[RegExp, ResourceType]> = [
+  [/\.(?:js|mjs|cjs|jsx|ts|tsx)(?:$|\?)/i, 'script'],
+  [/\.css(?:$|\?)/i, 'stylesheet'],
+  [/\.(?:png|jpe?g|gif|webp|avif|svg|ico|bmp)(?:$|\?)/i, 'image'],
+  [/\.(?:woff2?|ttf|otf|eot)(?:$|\?)/i, 'font'],
+  [/\.(?:mp4|webm|ogg|mp3|wav|m4a|mov)(?:$|\?)/i, 'media'],
+]
+
+const CONTENT_TYPE_TYPES: Array<[RegExp, ResourceType]> = [
+  [/^text\/html/i, 'document'],
+  [/javascript|ecmascript/i, 'script'],
+  [/^text\/css/i, 'stylesheet'],
+  [/^image\//i, 'image'],
+  [/^font\/|application\/(?:x-)?font|application\/vnd\.ms-fontobject/i, 'font'],
+  [/^(?:audio|video)\//i, 'media'],
+]
+
+/**
+ * Names a resource, preferring what the server said over what the URL implies.
+ *
+ * A URL extension is a guess: plenty of scripts are served from paths with no
+ * extension at all. The `Content-Type` is the server's own answer, so it wins
+ * whenever there is one.
+ */
+export function classifyResource(url: string, contentType?: string | null): ResourceType {
+  if (contentType) {
+    for (const [pattern, type] of CONTENT_TYPE_TYPES) {
+      if (pattern.test(contentType))
+        return type
+    }
+  }
+
+  for (const [pattern, type] of EXTENSION_TYPES) {
+    if (pattern.test(url))
+      return type
+  }
+
+  return 'other'
+}
+
+/** Pulls one attribute out of a tag's attribute text. */
+function attribute(tag: string, name: string): string | null {
+  const match = tag.match(new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i'))
+  if (!match)
+    return null
+  return match[1] ?? match[2] ?? match[3] ?? null
+}
+
+/** The first candidate in a `srcset`, which is the one a plain reader would take. */
+function firstSrcsetCandidate(srcset: string): string | null {
+  const first = srcset.split(',')[0]?.trim().split(/\s+/)[0]
+  return first || null
+}
+
+const TAG_RE = /<(script|link|img|source|video|audio)\b([^>]*)>/gi
+
+/**
+ * Reads every subresource the served HTML asks for.
+ *
+ * Duplicates collapse, because a browser fetches one URL once however many
+ * tags name it. Anything that is not a public http URL is dropped here rather
+ * than at fetch time, so one rule decides what this tool will request.
+ */
+export function extractResourceRefs(html: string, baseUrl: string): ResourceRef[] {
+  const seen = new Set<string>()
+  const refs: ResourceRef[] = []
+
+  for (const match of html.matchAll(TAG_RE)) {
+    const tag = match[1]!.toLowerCase()
+    const attrs = match[2] ?? ''
+
+    let raw: string | null = null
+    let hinted: ResourceType | null = null
+
+    if (tag === 'script') {
+      raw = attribute(attrs, 'src')
+      hinted = 'script'
+    }
+    else if (tag === 'link') {
+      const rel = (attribute(attrs, 'rel') || '').toLowerCase()
+      // Only the rels that make the browser fetch bytes for this page.
+      if (!/\b(?:stylesheet|preload|modulepreload|icon)\b/.test(rel))
+        continue
+      raw = attribute(attrs, 'href')
+      if (rel.includes('stylesheet'))
+        hinted = 'stylesheet'
+      const asAttr = (attribute(attrs, 'as') || '').toLowerCase()
+      if (asAttr === 'font')
+        hinted = 'font'
+      else if (asAttr === 'style')
+        hinted = 'stylesheet'
+      else if (asAttr === 'script')
+        hinted = 'script'
+      else if (asAttr === 'image' || rel.includes('icon'))
+        hinted = 'image'
+    }
+    else if (tag === 'img' || tag === 'source') {
+      const srcset = attribute(attrs, 'srcset')
+      raw = (srcset ? firstSrcsetCandidate(srcset) : null) || attribute(attrs, 'src')
+      hinted = tag === 'img' ? 'image' : null
+    }
+    else {
+      raw = attribute(attrs, 'src')
+      hinted = 'media'
+    }
+
+    if (!raw)
+      continue
+
+    const parsed = parsePublicHttpUrl(raw.trim(), baseUrl)
+    if (parsed._tag === 'err')
+      continue
+
+    const href = parsed.url.toString()
+    if (seen.has(href))
+      continue
+    seen.add(href)
+
+    refs.push({ url: href, type: hinted ?? classifyResource(href) })
+  }
+
+  return refs
+}
+
+export interface WeightEntry {
+  url: string
+  type: ResourceType
+  size: number
+}
+
+export interface ResourceGroup {
+  type: ResourceType
+  count: number
+  size: number
+}
+
+export interface WeightSummary {
+  totalSize: number
+  totalRequests: number
+  groups: ResourceGroup[]
+  largestResources: Array<{ url: string, size: number, type: ResourceType }>
+}
+
+/** How many entries the "largest resources" list shows, matching the PSI panel. */
+const LARGEST_RESOURCE_COUNT = 10
+
+/** Groups measured resources into the breakdown the tool renders. */
+export function summarizeWeight(entries: readonly WeightEntry[]): WeightSummary {
+  const groups = new Map<ResourceType, ResourceGroup>()
+
+  for (const entry of entries) {
+    const group = groups.get(entry.type) ?? { type: entry.type, count: 0, size: 0 }
+    group.count++
+    group.size += entry.size
+    groups.set(entry.type, group)
+  }
+
+  return {
+    totalSize: entries.reduce((total, entry) => total + entry.size, 0),
+    totalRequests: entries.length,
+    groups: [...groups.values()].sort((a, b) => b.size - a.size),
+    largestResources: [...entries]
+      .sort((a, b) => b.size - a.size)
+      .slice(0, LARGEST_RESOURCE_COUNT)
+      .map(({ url, size, type }) => ({ url, size, type })),
+  }
+}

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -197,6 +197,181 @@ export function extractResourceRefs(html: string, baseUrl: string): ResourceRef[
   return refs
 }
 
+/** Nothing is fetched past this, so one enormous page cannot hold a Worker open. */
+export const RESOURCE_LIMIT = 120
+
+/** The most of one body this tool will ever hold in memory. */
+export const MAX_BODY_BYTES = 5 * 1024 * 1024
+
+export type BodyRead
+  = | { _tag: 'ok', bytes: Uint8Array }
+    | { _tag: 'over-cap' }
+
+function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
+  const bytes = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+/**
+ * Reads a response body under a hard byte cap.
+ *
+ * The cap is what bounds memory. The reader stops and cancels the stream the
+ * moment the body passes it, so a fast endless stream cannot fill the Worker's
+ * isolate. `over-cap` says the resource is bigger than anything this tool
+ * would report.
+ */
+export async function readBodyCapped(response: Response, cap: number): Promise<BodyRead> {
+  const body = response.body
+  if (!body)
+    return { _tag: 'ok', bytes: new Uint8Array(0) }
+
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done)
+      return { _tag: 'ok', bytes: concatChunks(chunks, total) }
+
+    total += value.byteLength
+    if (total > cap) {
+      await reader.cancel().catch(() => {
+        // A cancel on a stream that already failed can reject. That changes
+        // nothing: the outcome is already decided.
+      })
+      return { _tag: 'over-cap' }
+    }
+    chunks.push(value)
+  }
+}
+
+export type MeasureOutcome
+  = | { _tag: 'measured', size: number, contentType: string | null }
+    | { _tag: 'absent' }
+    | { _tag: 'unmeasured' }
+
+export interface MeasureResourceOptions {
+  /** Absolute time after which the whole run stops. */
+  deadline: number
+  /** The longest a single resource may take. */
+  timeoutMs: number
+  /** The most of one body to hold in memory. */
+  maxBodyBytes: number
+  userAgent: string
+  /** The fetch to use. Production passes the platform fetch; tests pass a stub. */
+  fetchLike?: typeof fetch
+}
+
+/** True for a rejection the clock caused, where waiting longer could still succeed. */
+function isTimedOut(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')
+}
+
+/**
+ * Reads a size out of response headers without downloading anything.
+ *
+ * `Content-Range` carries the full length even on a one-byte request, and
+ * `Content-Length` answers on a HEAD that bothers to send it. A compressed
+ * chunked response sends neither, which is why a download is still the last
+ * resort.
+ */
+function sizeFromHeaders(response: Response | null): { size: number, contentType: string | null } | null {
+  if (!response)
+    return null
+
+  const contentRange = response.headers.get('content-range')
+  const total = contentRange ? Number(contentRange.split('/')[1]) : Number.NaN
+  if (Number.isFinite(total) && total > 0)
+    return { size: total, contentType: response.headers.get('content-type') }
+
+  if (!response.ok)
+    return null
+
+  const declared = Number(response.headers.get('content-length'))
+  // A one-byte length is the range response itself, not the resource.
+  if (Number.isFinite(declared) && declared > 1)
+    return { size: declared, contentType: response.headers.get('content-type') }
+
+  return null
+}
+
+/**
+ * Measures one resource, spending as little as the server allows.
+ *
+ * Servers disagree about which cheap probe they answer. Cloudflare in front of
+ * this site answers HEAD with a length; nuxt.com answers HEAD with no length
+ * at all but serves ranges. Trying HEAD, then a one-byte range, then a
+ * download turns most resources into one small round trip.
+ *
+ * The outcome says which of three things happened:
+ * - `measured`: a size is known.
+ * - `absent`: the resource is definitively not there. It answered with an
+ *   error status after every probe, or the connection failed in a way more
+ *   time would not fix. This is a fact about the page, so it does not make a
+ *   measurement incomplete.
+ * - `unmeasured`: the run could not read it. The clock or the byte cap
+ *   stopped it. This is what makes a measurement incomplete.
+ *
+ * Every path reports the identity length, so these are uncompressed bytes.
+ */
+export async function measureResource(url: string, options: MeasureResourceOptions): Promise<MeasureOutcome> {
+  const doFetch = options.fetchLike ?? globalThis.fetch
+  const budget = () => Math.min(options.timeoutMs, options.deadline - Date.now())
+
+  const attempt = (init: RequestInit): Promise<Response | MeasureOutcome> => {
+    if (budget() <= 0)
+      return Promise.resolve({ _tag: 'unmeasured' })
+    return doFetch(url, {
+      ...init,
+      headers: { 'user-agent': options.userAgent, ...(init.headers as Record<string, string> | undefined) },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(budget()),
+    }).then(
+      response => response,
+      (error: unknown): MeasureOutcome => isTimedOut(error) ? { _tag: 'unmeasured' } : { _tag: 'absent' },
+    )
+  }
+
+  const probes: RequestInit[] = [
+    { method: 'HEAD' },
+    { headers: { range: 'bytes=0-0' } },
+  ]
+
+  for (const probe of probes) {
+    const probed = await attempt(probe)
+    if ('_tag' in probed)
+      return probed
+
+    const sized = sizeFromHeaders(probed)
+    if (sized)
+      return { _tag: 'measured', size: sized.size, contentType: sized.contentType }
+  }
+
+  const response = await attempt({})
+  if ('_tag' in response)
+    return response
+
+  if (!response.ok)
+    return { _tag: 'absent' }
+
+  const body = await readBodyCapped(response, options.maxBodyBytes).catch(() => {
+    // A body that stops mid-stream leaves no length to report, so the
+    // resource is counted as unmeasured rather than guessed at.
+    return null
+  })
+
+  if (!body || body._tag === 'over-cap')
+    return { _tag: 'unmeasured' }
+
+  return { _tag: 'measured', size: body.bytes.byteLength, contentType: response.headers.get('content-type') }
+}
+
 export interface WeightEntry {
   url: string
   type: ResourceType
@@ -238,5 +413,38 @@ export function summarizeWeight(entries: readonly WeightEntry[]): WeightSummary 
       .sort((a, b) => b.size - a.size)
       .slice(0, LARGEST_RESOURCE_COUNT)
       .map(({ url, size, type }) => ({ url, size, type })),
+  }
+}
+
+export interface WeightCompleteness {
+  complete: boolean
+  /** Resources discovered but never attempted, because the limit stopped the run. */
+  skipped: number
+}
+
+/**
+ * Decides whether a run measured the whole page.
+ *
+ * A resource that is gone is part of the truth: a 404 or a refused connection
+ * contributes no bytes and the total still stands. Only a run that stopped
+ * early leaves the total short. That happens when the clock or the byte cap
+ * cut resources unread, or when more resources were discovered than the limit
+ * allows.
+ *
+ * - `discovered`: every resource the HTML asks for.
+ * - `attempted`: the ones the run tried to measure.
+ * - `measured`: the ones that produced a size.
+ * - `budgetExhausted`: true when the run stopped before reading everything it
+ *   attempted.
+ */
+export function assessCompleteness(
+  discovered: number,
+  attempted: number,
+  measured: number,
+  budgetExhausted: boolean,
+): WeightCompleteness {
+  return {
+    complete: discovered <= RESOURCE_LIMIT && (!budgetExhausted || measured >= attempted),
+    skipped: Math.max(0, discovered - attempted),
   }
 }

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -114,12 +114,17 @@ function ipv6Groups(raw: string): number[] | null {
  * canonical form is the embedded dotted quad. Everything else passes through.
  */
 function canonicalGuardHost(hostname: string): string {
-  if (!hostname.includes(':'))
-    return hostname
+  // One trailing dot is the fully qualified spelling of the same name: DNS
+  // resolves `localhost.` exactly as it resolves `localhost`, and the URL
+  // parser hands the dot through. The guard matches the name without it.
+  const host = hostname.endsWith('.') ? hostname.slice(0, -1) : hostname
 
-  const groups = ipv6Groups(hostname)
+  if (!host.includes(':'))
+    return host
+
+  const groups = ipv6Groups(host)
   if (!groups)
-    return hostname
+    return host
 
   const firstFiveZero = groups.slice(0, 5).every(group => group === 0)
   const embeddedIPv4 = firstFiveZero && (groups[5] === 0xFFFF || groups[5] === 0)
@@ -543,6 +548,43 @@ export async function readBodyCapped(response: Response, cap: number): Promise<B
   }
 }
 
+type BodyCount
+  = | { _tag: 'ok', bytes: number }
+    | { _tag: 'over-cap' }
+
+/**
+ * Counts a response body under a hard byte cap without keeping any of it.
+ *
+ * The subresource download only needs a length, and sixteen downloads run at
+ * once: retaining every chunk and copying them into one buffer would let a
+ * hostile page meet the Worker's memory cap. One chunk is live at a time
+ * here, and `over-cap` still says the resource is bigger than anything this
+ * tool would report.
+ */
+async function countBodyCapped(response: Response, cap: number): Promise<BodyCount> {
+  const body = response.body
+  if (!body)
+    return { _tag: 'ok', bytes: 0 }
+
+  const reader = body.getReader()
+  let total = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done)
+      return { _tag: 'ok', bytes: total }
+
+    total += value.byteLength
+    if (total > cap) {
+      await reader.cancel().catch(() => {
+        // A cancel on a stream that already failed can reject. That changes
+        // nothing: the outcome is already decided.
+      })
+      return { _tag: 'over-cap' }
+    }
+  }
+}
+
 export type MeasureOutcome
   = | { _tag: 'measured', size: number, contentType: string | null }
     | { _tag: 'absent' }
@@ -725,16 +767,16 @@ export async function measureResource(url: string, options: MeasureResourceOptio
   if (!response.ok)
     return { _tag: isResourceGone(response.status) ? 'absent' : 'unmeasured' }
 
-  const body = await readBodyCapped(response, options.maxBodyBytes).catch(() => {
+  const counted = await countBodyCapped(response, options.maxBodyBytes).catch(() => {
     // A body that stops mid-stream leaves no length to report, so the
     // resource is counted as unmeasured rather than guessed at.
     return null
   })
 
-  if (!body || body._tag === 'over-cap')
+  if (!counted || counted._tag === 'over-cap')
     return { _tag: 'unmeasured' }
 
-  return { _tag: 'measured', size: body.bytes.byteLength, contentType: response.headers.get('content-type') }
+  return { _tag: 'measured', size: counted.bytes, contentType: response.headers.get('content-type') }
 }
 
 export interface WeightEntry {

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -515,11 +515,6 @@ export interface MeasureResourceOptions {
   fetchLike?: typeof fetch
 }
 
-/** True for a rejection the clock caused, where waiting longer could still succeed. */
-function isTimedOut(error: unknown): boolean {
-  return error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')
-}
-
 /**
  * Reads a size out of response headers without downloading anything.
  *
@@ -558,12 +553,19 @@ function sizeFromHeaders(response: Response | null): { size: number, contentType
  *
  * The outcome says which of three things happened:
  * - `measured`: a size is known.
- * - `absent`: the resource is definitively not there. It answered with an
- *   error status after every probe, or the connection failed in a way more
- *   time would not fix. This is a fact about the page, so it does not make a
+ * - `absent`: the server answered and the answer was definitive. An error
+ *   status after every probe, or a redirect leading somewhere this tool will
+ *   not follow. This is a fact about the page, so it does not make a
  *   measurement incomplete.
- * - `unmeasured`: the run could not read it. The clock or the byte cap
- *   stopped it. This is what makes a measurement incomplete.
+ * - `unmeasured`: the run could not find out. The clock, the byte cap, or a
+ *   connection that never produced an answer. This is what makes a measurement
+ *   incomplete.
+ *
+ * The split is the difference between a page and a network. Only a response
+ * says something about the page. A rejected fetch is a reset, a refused
+ * connection, a DNS failure or a TLS error, and the same request a moment later
+ * may well succeed, so treating one as `absent` would quietly shrink the total
+ * while still calling the run complete.
  *
  * Every path reports the identity length, so these are uncompressed bytes.
  */
@@ -581,7 +583,9 @@ export async function measureResource(url: string, options: MeasureResourceOptio
       signal: AbortSignal.timeout(budget()),
     }).then(
       response => response,
-      (error: unknown): MeasureOutcome => isTimedOut(error) ? { _tag: 'unmeasured' } : { _tag: 'absent' },
+      // No response means no answer about the page, whether the clock ran out
+      // or the connection failed. Either way the size stays unknown.
+      (): MeasureOutcome => ({ _tag: 'unmeasured' }),
     )
   }
 

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -264,7 +264,87 @@ function firstSrcsetCandidate(srcset: string): string | null {
   return first || null
 }
 
-const TAG_RE = /<(script|link|img|source|video|audio)\b([^>]*)>/gi
+/** Tags whose content is text, not markup, so anything inside them is not a tag. */
+const RAW_TEXT_ELEMENTS = new Set(['script', 'style', 'textarea', 'title'])
+
+/** The elements that can name a subresource. */
+const RESOURCE_ELEMENTS = new Set(['script', 'link', 'img', 'source', 'video', 'audio'])
+
+interface ScannedTag {
+  name: string
+  attrs: string
+}
+
+/**
+ * Walks the HTML and yields each resource tag with its attribute text.
+ *
+ * A regex cannot do this. `<[^>]*>` ends the tag at the first `>`, and a `>`
+ * inside a quoted attribute value is legal HTML, so `<img alt="a > b" src=…>`
+ * loses its `src` and the resource disappears from the total. The same scan
+ * has to skip comments and the contents of script and style, or a tag written
+ * inside either is counted as a resource the page never requests.
+ */
+function* scanTags(html: string): Generator<ScannedTag> {
+  let index = 0
+
+  while (index < html.length) {
+    const open = html.indexOf('<', index)
+    if (open === -1)
+      return
+
+    if (html.startsWith('<!--', open)) {
+      const close = html.indexOf('-->', open + 4)
+      // An unterminated comment runs to the end of the document.
+      if (close === -1)
+        return
+      index = close + 3
+      continue
+    }
+
+    const nameMatch = /^<([a-z][a-z0-9-]*)/i.exec(html.slice(open, open + 32))
+    if (!nameMatch) {
+      index = open + 1
+      continue
+    }
+
+    const name = nameMatch[1]!.toLowerCase()
+    let cursor = open + nameMatch[0].length
+    let quote: string | null = null
+
+    // Walk to the tag's real end, ignoring a `>` inside a quoted value.
+    while (cursor < html.length) {
+      const char = html[cursor]!
+      if (quote) {
+        if (char === quote)
+          quote = null
+      }
+      else if (char === '"' || char === '\'') {
+        quote = char
+      }
+      else if (char === '>') {
+        break
+      }
+      cursor++
+    }
+
+    const attrs = html.slice(open + nameMatch[0].length, cursor)
+    const selfClosing = attrs.trimEnd().endsWith('/')
+
+    if (RESOURCE_ELEMENTS.has(name))
+      yield { name, attrs }
+
+    index = cursor + 1
+
+    // Everything inside a raw text element is text. Skipping it stops a tag
+    // written in a string or a stylesheet from being read as markup.
+    if (RAW_TEXT_ELEMENTS.has(name) && !selfClosing) {
+      const closing = html.toLowerCase().indexOf(`</${name}`, index)
+      if (closing === -1)
+        return
+      index = closing + name.length + 2
+    }
+  }
+}
 
 /**
  * Reads every subresource the served HTML asks for.
@@ -277,10 +357,7 @@ export function extractResourceRefs(html: string, baseUrl: string): ResourceRef[
   const seen = new Set<string>()
   const refs: ResourceRef[] = []
 
-  for (const match of html.matchAll(TAG_RE)) {
-    const tag = match[1]!.toLowerCase()
-    const attrs = match[2] ?? ''
-
+  for (const { name: tag, attrs } of scanTags(html)) {
     let raw: string | null = null
     let hinted: ResourceType | null = null
 

--- a/shared/page-weight.ts
+++ b/shared/page-weight.ts
@@ -47,10 +47,96 @@ const BLOCKED_HOST_PATTERNS: RegExp[] = [
 ]
 
 /**
+ * Reads an IPv6 address as its eight 16-bit groups, or says the text is not
+ * one.
+ *
+ * The URL parser hands the hostname over in its normalized bracketed form
+ * (`[::ffff:7f00:1]`, all groups present or one `::`), but the embedded
+ * dotted-quad spelling is accepted too so this stays right even for text that
+ * skipped that parser.
+ */
+function ipv6Groups(raw: string): number[] | null {
+  let text = raw
+  if (text.startsWith('[') && text.endsWith(']'))
+    text = text.slice(1, -1)
+  if (!text)
+    return null
+
+  let head = text
+  let tailGroups: number[] = []
+  if (text.includes('.')) {
+    const lastColon = text.lastIndexOf(':')
+    if (lastColon === -1)
+      return null
+    const quad = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(text.slice(lastColon + 1))
+    if (!quad)
+      return null
+    const bytes = [quad[1], quad[2], quad[3], quad[4]].map(Number)
+    if (bytes.some(byte => byte > 255))
+      return null
+    tailGroups = [(bytes[0]! << 8) | bytes[1]!, (bytes[2]! << 8) | bytes[3]!]
+    head = text.slice(0, lastColon)
+  }
+
+  const halves = head.split('::')
+  if (halves.length > 2)
+    return null
+  const left = halves[0] === '' ? [] : halves[0]!.split(':')
+  const right = halves.length === 2 ? (halves[1] === '' ? [] : halves[1]!.split(':')) : []
+  for (const group of [...left, ...right]) {
+    if (!/^[0-9a-f]{1,4}$/i.test(group))
+      return null
+  }
+
+  const fill = 8 - left.length - right.length - tailGroups.length
+  if (fill < 0 || (halves.length === 1 && fill !== 0))
+    return null
+
+  const parse = (group: string) => Number.parseInt(group, 16)
+  const groups: number[] = []
+  for (const group of left)
+    groups.push(parse(group))
+  for (let index = 0; index < fill; index++)
+    groups.push(0)
+  for (const group of right)
+    groups.push(parse(group))
+  groups.push(...tailGroups)
+  return groups
+}
+
+/**
+ * The host a guard pattern can reason about.
+ *
+ * An IPv6 address whose last 32 bits carry an IPv4 address, mapped
+ * (`::ffff:0:0/96`) or compatible (`::/96`), is that IPv4 address to the
+ * machine that connects. The URL parser keeps such a host in hex form
+ * (`[::ffff:7f00:1]`), which the IPv4 patterns would never match, so the
+ * canonical form is the embedded dotted quad. Everything else passes through.
+ */
+function canonicalGuardHost(hostname: string): string {
+  if (!hostname.includes(':'))
+    return hostname
+
+  const groups = ipv6Groups(hostname)
+  if (!groups)
+    return hostname
+
+  const firstFiveZero = groups.slice(0, 5).every(group => group === 0)
+  const embeddedIPv4 = firstFiveZero && (groups[5] === 0xFFFF || groups[5] === 0)
+  if (!embeddedIPv4)
+    return hostname
+
+  const bytes = [groups[6]! >> 8, groups[6]! & 0xFF, groups[7]! >> 8, groups[7]! & 0xFF]
+  return bytes.join('.')
+}
+
+/**
  * Parses one URL into something safe to fetch, or says why it is not.
  *
- * Every URL the measurement touches passes through here once, including the
- * ones read out of the fetched HTML, which the page author controls.
+ * Every URL the measurement touches passes through here once: the submitted
+ * page URL, every ref read out of the fetched HTML, and every redirect hop a
+ * response names. The last two are page-author controlled, which is why the
+ * guard runs on each of them.
  */
 export function parsePublicHttpUrl(raw: string, base?: string): UrlParse {
   let url: URL
@@ -67,7 +153,7 @@ export function parsePublicHttpUrl(raw: string, base?: string): UrlParse {
   if (!url.hostname)
     return { _tag: 'err', reason: 'no host' }
 
-  if (BLOCKED_HOST_PATTERNS.some(pattern => pattern.test(url.hostname)))
+  if (BLOCKED_HOST_PATTERNS.some(pattern => pattern.test(canonicalGuardHost(url.hostname))))
     return { _tag: 'err', reason: 'host is not public' }
 
   return { _tag: 'ok', url }
@@ -113,9 +199,14 @@ export function classifyResource(url: string, contentType?: string | null): Reso
   return 'other'
 }
 
-/** Pulls one attribute out of a tag's attribute text. */
+/**
+ * Pulls one attribute out of a tag's attribute text.
+ *
+ * The name is anchored on the left, since `\b` holds between `-` and a letter
+ * and would read `data-src` as `src`.
+ */
 function attribute(tag: string, name: string): string | null {
-  const match = tag.match(new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i'))
+  const match = tag.match(new RegExp(`(?<![\\w-])${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i'))
   if (!match)
     return null
   return match[1] ?? match[2] ?? match[3] ?? null
@@ -256,6 +347,39 @@ export type MeasureOutcome
     | { _tag: 'absent' }
     | { _tag: 'unmeasured' }
 
+/** The redirect statuses the fetch spec follows. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+
+/** The most hops one request may chase before it gives up, as a browser would. */
+export const MAX_REDIRECT_HOPS = 5
+
+export type RedirectHop
+  = | { _tag: 'follow', url: string }
+    | { _tag: 'blocked' }
+    | { _tag: 'not-redirect' }
+
+/**
+ * Reads where a redirect response says to go next.
+ *
+ * - `follow`: the Location resolved and passed the public-host guard; chase it.
+ * - `blocked`: the hop is missing or points somewhere this tool never fetches.
+ * - `not-redirect`: the response is the answer, not a signpost.
+ *
+ * Redirects are followed by hand for exactly this check: the platform's
+ * `follow` mode would hop to an internal address the guard never saw.
+ */
+export function redirectHop(response: Response, baseUrl: string): RedirectHop {
+  if (!REDIRECT_STATUSES.has(response.status))
+    return { _tag: 'not-redirect' }
+
+  const location = response.headers.get('location')
+  if (!location)
+    return { _tag: 'blocked' }
+
+  const parsed = parsePublicHttpUrl(location, baseUrl)
+  return parsed._tag === 'ok' ? { _tag: 'follow', url: parsed.url.toString() } : { _tag: 'blocked' }
+}
+
 export interface MeasureResourceOptions {
   /** Absolute time after which the whole run stops. */
   deadline: number
@@ -324,13 +448,13 @@ export async function measureResource(url: string, options: MeasureResourceOptio
   const doFetch = options.fetchLike ?? globalThis.fetch
   const budget = () => Math.min(options.timeoutMs, options.deadline - Date.now())
 
-  const attempt = (init: RequestInit): Promise<Response | MeasureOutcome> => {
+  const attempt = (target: string, init: RequestInit): Promise<Response | MeasureOutcome> => {
     if (budget() <= 0)
       return Promise.resolve({ _tag: 'unmeasured' })
-    return doFetch(url, {
+    return doFetch(target, {
       ...init,
       headers: { 'user-agent': options.userAgent, ...(init.headers as Record<string, string> | undefined) },
-      redirect: 'follow',
+      redirect: 'manual',
       signal: AbortSignal.timeout(budget()),
     }).then(
       response => response,
@@ -338,13 +462,36 @@ export async function measureResource(url: string, options: MeasureResourceOptio
     )
   }
 
+  /**
+   * Runs one probe, following only redirect hops the guard calls public.
+   *
+   * A hop the guard refuses, or a chase that never settles, means the resource
+   * answers with nowhere public to measure: `absent`, a fact about the page.
+   */
+  const probe = async (init: RequestInit): Promise<Response | MeasureOutcome> => {
+    let target = url
+    for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+      const response = await attempt(target, init)
+      if ('_tag' in response)
+        return response
+
+      const next = redirectHop(response, target)
+      if (next._tag === 'not-redirect')
+        return response
+      if (next._tag === 'blocked')
+        return { _tag: 'absent' }
+      target = next.url
+    }
+    return { _tag: 'absent' }
+  }
+
   const probes: RequestInit[] = [
     { method: 'HEAD' },
     { headers: { range: 'bytes=0-0' } },
   ]
 
-  for (const probe of probes) {
-    const probed = await attempt(probe)
+  for (const probeInit of probes) {
+    const probed = await probe(probeInit)
     if ('_tag' in probed)
       return probed
 
@@ -353,7 +500,7 @@ export async function measureResource(url: string, options: MeasureResourceOptio
       return { _tag: 'measured', size: sized.size, contentType: sized.contentType }
   }
 
-  const response = await attempt({})
+  const response = await probe({})
   if ('_tag' in response)
     return response
 

--- a/shared/run-gate.ts
+++ b/shared/run-gate.ts
@@ -1,0 +1,23 @@
+/**
+ * Supersedes stale async resolutions.
+ *
+ * A request that is still in flight when a newer one starts must not land its
+ * answer. The page-size fast pass hit this: a slow response for URL A could
+ * resolve after the visitor had already submitted URL B, and B's screen would
+ * show A's weight breakdown. A run records its generation when it starts and
+ * checks it when the response lands.
+ */
+export interface RunGate {
+  /** Starts a new run and returns the token that identifies it. */
+  begin: () => number
+  /** True when the token still belongs to the newest run. */
+  isCurrent: (token: number) => boolean
+}
+
+export function createRunGate(): RunGate {
+  let current = 0
+  return {
+    begin: () => ++current,
+    isCurrent: token => token === current,
+  }
+}

--- a/tests/page-weight-handler.test.ts
+++ b/tests/page-weight-handler.test.ts
@@ -1,0 +1,65 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import { registerHooks } from 'node:module'
+import test from 'node:test'
+import { createError } from 'h3'
+
+const root = new URL('../', import.meta.url)
+
+// The handler names its imports with Nuxt's `~~` root alias, which plain Node
+// does not resolve, so tests map that alias onto the repository root here.
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('~~/'))
+      return nextResolve(`${new URL(specifier.slice(3), root).href}.ts`, context)
+    return nextResolve(specifier, context)
+  },
+})
+
+// The handler is written against Nitro's auto-imports. Tests provide the ones
+// it uses, keeping the fetch stub the only thing under test.
+const globals = globalThis as unknown as Record<string, unknown>
+globals.defineCachedEventHandler = (handler: unknown) => handler
+globals.checkFreeToolRateLimit = async () => {}
+globals.getQuery = (event: { query?: Record<string, unknown> }) => event.query ?? {}
+globals.normalizeUrl = (url: string) => url
+globals.validateUrl = async (url: string) => url
+globals.trackToolRequest = (_event: unknown, _meta: unknown, work: () => unknown) => work()
+globals.createError = createError
+
+const { default: handler } = await import('../layers/tools/server/api/tools/page-weight.get.ts')
+
+/**
+ * A response whose body stream dies after the first chunk: the page loaded,
+ * then the connection reset while the body was still streaming. The document
+ * timeout governs body streaming too, so this is the shape a slow or reset
+ * page takes at the document read.
+ */
+function pageWhoseBodyAborts(): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('<html><body>'))
+    },
+    pull(controller) {
+      controller.error(Object.assign(new Error('connection reset mid-body'), { name: 'TypeError' }))
+    },
+  })
+  return new Response(stream, { status: 200, headers: { 'content-type': 'text/html' } })
+}
+
+test('answers 502 when the document body aborts mid-stream', async () => {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async () => pageWhoseBodyAborts()) as typeof fetch
+
+  try {
+    await assert.rejects(
+      handler({ query: { url: 'https://example.com/' } } as unknown as Parameters<typeof handler>[0]),
+      (error: unknown) =>
+        (error as { statusCode?: number }).statusCode === 502
+        && (error as { message?: string }).message === 'Could not load the page',
+    )
+  }
+  finally {
+    globalThis.fetch = realFetch
+  }
+})

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -396,6 +396,44 @@ test('stops cleanly on an unterminated comment', () => {
 })
 
 /**
+ * The raw text skip used to lowercase the entire document once per script,
+ * style, or title element. A page of many inline scripts paid a full extra
+ * document pass per element, and a skip computed on the lowercased copy
+ * pointed back into the original at a shifted offset.
+ */
+
+test('scans a page of many inline scripts well under a second', () => {
+  const block = `<script>var data = "${'x'.repeat(1024)}";</script>`
+  const parts: string[] = []
+  let size = 0
+  while (size < 4 * 1024 * 1024) {
+    parts.push(block)
+    size += block.length
+  }
+  parts.push('<img src="/after.png">')
+  const html = parts.join('')
+
+  const start = performance.now()
+  extractResourceRefs(html, 'https://example.com/')
+  const elapsed = performance.now() - start
+
+  assert.ok(
+    elapsed < 1000,
+    `scanning a ${Math.round(html.length / 1024 / 1024)}MB page took ${Math.round(elapsed)}ms`,
+  )
+})
+
+test('reads tags that follow a script in a document that changes length under lowercasing', () => {
+  // `İ` lowercases to two characters, so a skip computed on a lowercased copy
+  // resumed the original at a shifted offset and dropped the img.
+  const html = 'İİ<script>var x = "<img src=/ghost.png>"</script><img src="/after.png">'
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/after.png'])
+})
+
+/**
  * A response says something about the page. A rejected fetch says something
  * about the network, and the two must not be confused: counting a connection
  * reset as a definitive answer shrinks the total while still calling the run

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -122,6 +122,36 @@ test('does not mistake data-src for the src it shadows', () => {
   assert.ok(!refs.some(ref => ref.url === 'https://example.com/lazy.png'))
 })
 
+test('decodes character references in an attribute value', () => {
+  const refs = extractResourceRefs(
+    '<img src="/px?a=1&amp;b=2">',
+    'https://example.com/',
+  )
+
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0]?.url, 'https://example.com/px?a=1&b=2')
+})
+
+test('decodes numeric character references in an attribute value', () => {
+  const refs = extractResourceRefs(
+    '<img src="/px?a=1&#38;b=2">',
+    'https://example.com/',
+  )
+
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0]?.url, 'https://example.com/px?a=1&b=2')
+})
+
+test('dedupes an encoded spelling against its decoded spelling', () => {
+  const refs = extractResourceRefs(
+    '<img src="/px?a=1&amp;b=2"><img src="/px?a=1&b=2">',
+    'https://example.com/',
+  )
+
+  assert.equal(refs.length, 1)
+  assert.equal(refs[0]?.url, 'https://example.com/px?a=1&b=2')
+})
+
 test('drops a subresource pointing back inside a network', () => {
   const refs = extractResourceRefs(PAGE, 'https://example.com/')
 

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -5,6 +5,7 @@ import {
   assessCompleteness,
   classifyResource,
   extractResourceRefs,
+  isResourceGone,
   MAX_BODY_BYTES,
   measureResource,
   parsePublicHttpUrl,
@@ -478,4 +479,71 @@ test('refuses a private host before any request is attempted', () => {
   // validateUrl, whose reachability probe would otherwise make the request.
   for (const raw of ['http://127.0.0.1/', 'http://169.254.169.254/', 'http://10.0.0.1/'])
     assert.equal(parsePublicHttpUrl(raw)._tag, 'err', raw)
+})
+
+/**
+ * `<base href>` changes what a relative reference means for the whole document.
+ * Ignoring it fetches paths the page never asks for and reports the result as
+ * the page's weight.
+ */
+
+test('resolves relative resources against a base href', () => {
+  const html = '<head><base href="https://cdn.example.com/assets/"></head><script src="app.js"></script>'
+
+  const refs = extractResourceRefs(html, 'https://example.com/page')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://cdn.example.com/assets/app.js'])
+})
+
+test('keeps using the document URL when there is no base href', () => {
+  const refs = extractResourceRefs('<script src="app.js"></script>', 'https://example.com/dir/page')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/dir/app.js'])
+})
+
+test('takes only the first base href, the way a browser does', () => {
+  const html = '<base href="https://a.example.com/"><base href="https://b.example.com/"><img src="x.png">'
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://a.example.com/x.png'])
+})
+
+test('ignores a base href pointing somewhere private', () => {
+  const html = '<base href="http://127.0.0.1/"><img src="x.png">'
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/x.png'])
+})
+
+/**
+ * A status has to say the resource is gone before its absence counts as a fact
+ * about the page. Being refused or throttled says nothing about the bytes.
+ */
+
+test('treats only a gone status as a fact about the page', () => {
+  for (const status of [404, 410])
+    assert.equal(isResourceGone(status), true, String(status))
+
+  for (const status of [401, 403, 429, 500, 502, 503])
+    assert.equal(isResourceGone(status), false, String(status))
+})
+
+test('leaves a refused resource unmeasured rather than absent', async () => {
+  const outcome = await measureResource('https://example.com/a.js', {
+    ...measureOptions,
+    fetchLike: () => Promise.resolve(new Response('', { status: 403 })),
+  })
+
+  assert.equal(outcome._tag, 'unmeasured')
+})
+
+test('leaves a throttled resource unmeasured rather than absent', async () => {
+  const outcome = await measureResource('https://example.com/a.js', {
+    ...measureOptions,
+    fetchLike: () => Promise.resolve(new Response('', { status: 429 })),
+  })
+
+  assert.equal(outcome._tag, 'unmeasured')
 })

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -332,3 +332,64 @@ test('measures a body that stays under the byte cap', async () => {
   assert.equal(outcome.size, 3 * 1024 * 1024)
   assert.equal(outcome.contentType, 'text/plain')
 })
+
+/**
+ * The tag scan used to be `<[^>]*>`, which ends a tag at the first `>`. A `>`
+ * inside a quoted attribute value is legal HTML, so real resources vanished
+ * and tags written inside comments or scripts were counted as real.
+ */
+
+test('keeps a resource whose tag carries a quoted angle bracket', () => {
+  const html = '<img alt="width > height" src="/hero.png"><script src="/app.js"></script>'
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.ok(refs.some(ref => ref.url === 'https://example.com/hero.png'))
+  assert.ok(refs.some(ref => ref.url === 'https://example.com/app.js'))
+})
+
+test('keeps a resource whose tag carries a single-quoted angle bracket', () => {
+  const html = `<img alt='a > b' src="/hero.png">`
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/hero.png'])
+})
+
+test('ignores a tag written inside a comment', () => {
+  const html = '<!-- <script src="/ghost.js"></script> --><script src="/real.js"></script>'
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/real.js'])
+})
+
+test('ignores a tag written inside script content', () => {
+  const html = `<script>const markup = '<img src="/ghost.png">'</script><img src="/real.png">`
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/real.png'])
+})
+
+test('ignores a tag written inside style content', () => {
+  const html = `<style>/* <img src="/ghost.png"> */</style><img src="/real.png">`
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/real.png'])
+})
+
+test('still reads a script tag that has its own src before skipping its body', () => {
+  const html = '<script src="/app.js">console.log("<img src=\'/ghost.png\'>")</script>'
+
+  const refs = extractResourceRefs(html, 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/app.js'])
+})
+
+test('stops cleanly on an unterminated comment', () => {
+  const refs = extractResourceRefs('<img src="/a.png"><!-- <img src="/b.png">', 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/a.png'])
+})

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -2,8 +2,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  assessCompleteness,
   classifyResource,
   extractResourceRefs,
+  MAX_BODY_BYTES,
+  measureResource,
   parsePublicHttpUrl,
   summarizeWeight,
 } from '../shared/page-weight.ts'
@@ -134,4 +137,112 @@ test('ranks the largest resources and caps the list at ten', () => {
   assert.equal(summary.largestResources.length, 10)
   assert.equal(summary.largestResources[0]?.size, 1400)
   assert.equal(summary.largestResources.at(-1)?.size, 500)
+})
+
+test('a terminally absent subresource does not make the measurement incomplete', () => {
+  // Five resources discovered and attempted, one answered 404. The four that
+  // answered are the whole truth, so the total is shown.
+  const assessment = assessCompleteness(5, 5, 4, false)
+
+  assert.equal(assessment.complete, true)
+})
+
+test('budget exhaustion that leaves resources unmeasured makes it incomplete', () => {
+  const assessment = assessCompleteness(5, 5, 3, true)
+
+  assert.equal(assessment.complete, false)
+})
+
+test('resources past the limit keep the measurement incomplete', () => {
+  const assessment = assessCompleteness(130, 120, 120, false)
+
+  assert.equal(assessment.complete, false)
+  assert.equal(assessment.skipped, 10)
+})
+
+function measureWith(fetchLike: typeof fetch) {
+  return measureResource('https://example.com/resource', {
+    deadline: Date.now() + 10_000,
+    timeoutMs: 10_000,
+    maxBodyBytes: MAX_BODY_BYTES,
+    userAgent: 'test',
+    fetchLike,
+  })
+}
+
+test('counts a resource that answers 404 to every probe as absent', async () => {
+  const outcome = await measureWith(async () => new Response(null, { status: 404 }))
+
+  assert.equal(outcome._tag, 'absent')
+})
+
+test('counts a resource the deadline cut short as unmeasured', async () => {
+  const outcome = await measureResource('https://example.com/slow', {
+    deadline: Date.now() - 1,
+    timeoutMs: 10_000,
+    maxBodyBytes: MAX_BODY_BYTES,
+    userAgent: 'test',
+    fetchLike: async () => {
+      throw new Error('must not fetch once the deadline has passed')
+    },
+  })
+
+  assert.equal(outcome._tag, 'unmeasured')
+})
+
+test('reads a size from the range probe without downloading the body', async () => {
+  const outcome = await measureWith(async (_url, init) => init?.method === 'HEAD'
+    ? new Response(null, { status: 200 })
+    : new Response(null, { status: 206, headers: { 'content-range': 'bytes 0-0/12345' } }))
+
+  assert.ok(outcome._tag === 'measured')
+  assert.equal(outcome.size, 12345)
+})
+
+test('stops reading once a body passes the byte cap and reports it unmeasured', async () => {
+  const chunk = new Uint8Array(1024 * 1024).fill(0x61)
+  let chunksSent = 0
+  let cancelled = false
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (chunksSent >= 20) {
+        controller.close()
+        return
+      }
+      chunksSent++
+      controller.enqueue(chunk)
+    },
+    cancel() {
+      cancelled = true
+    },
+  })
+
+  const outcome = await measureWith(async () => new Response(stream, { headers: { 'content-type': 'application/octet-stream' } }))
+
+  assert.equal(outcome._tag, 'unmeasured')
+  // Six one-megabyte chunks pass the five-megabyte cap, and the stream holds
+  // twenty. Stopping well before the end is what keeps memory bounded.
+  assert.ok(chunksSent < 20, `read ${chunksSent} of 20 chunks`)
+  assert.ok(cancelled, 'expected the stream to be cancelled, not drained')
+})
+
+test('measures a body that stays under the byte cap', async () => {
+  const half = new Uint8Array(512 * 1024).fill(0x62)
+  let chunksSent = 0
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (chunksSent >= 6) {
+        controller.close()
+        return
+      }
+      chunksSent++
+      controller.enqueue(half)
+    },
+  })
+
+  const outcome = await measureWith(async () => new Response(stream, { headers: { 'content-type': 'text/plain' } }))
+
+  assert.ok(outcome._tag === 'measured')
+  assert.equal(outcome.size, 3 * 1024 * 1024)
+  assert.equal(outcome.contentType, 'text/plain')
 })

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -26,6 +26,22 @@ test('refuses a URL that points back inside a network', () => {
     assert.equal(parsePublicHttpUrl(raw)._tag, 'err', raw)
 })
 
+test('refuses an IPv6 host that embeds a blocked IPv4 address', () => {
+  const blocked = [
+    'http://[::ffff:127.0.0.1]/',
+    'http://[::ffff:10.0.0.1]/',
+    'http://[::ffff:192.168.1.1]/',
+    'http://[::7f00:1]/',
+    'http://[0:0:0:0:0:0:a00:1]/',
+  ]
+
+  for (const raw of blocked)
+    assert.equal(parsePublicHttpUrl(raw)._tag, 'err', raw)
+
+  // A mapped form of a public address is still public.
+  assert.equal(parsePublicHttpUrl('http://[::ffff:8.8.8.8]/')._tag, 'ok')
+})
+
 test('refuses a scheme that is not http', () => {
   for (const raw of ['file:///etc/passwd', 'data:text/html,hi', 'javascript:alert(1)'])
     assert.equal(parsePublicHttpUrl(raw)._tag, 'err', raw)
@@ -94,6 +110,16 @@ test('skips a link rel that fetches nothing for this page', () => {
   const refs = extractResourceRefs(PAGE, 'https://example.com/')
 
   assert.ok(!refs.some(ref => ref.url === 'https://example.com/canonical'))
+})
+
+test('does not mistake data-src for the src it shadows', () => {
+  const refs = extractResourceRefs(
+    '<html><body><img data-src="/lazy.png" src="/real.png"></body></html>',
+    'https://example.com/',
+  )
+
+  assert.ok(refs.some(ref => ref.url === 'https://example.com/real.png'))
+  assert.ok(!refs.some(ref => ref.url === 'https://example.com/lazy.png'))
 })
 
 test('drops a subresource pointing back inside a network', () => {
@@ -169,6 +195,36 @@ function measureWith(fetchLike: typeof fetch) {
     fetchLike,
   })
 }
+
+test('stops at a redirect hop that points inside a network instead of fetching it', async () => {
+  let calls = 0
+  const outcome = await measureWith(async () => {
+    calls++
+    return new Response(null, { status: 302, headers: { location: 'http://127.0.0.1/x' } })
+  })
+
+  assert.equal(calls, 1)
+  assert.equal(outcome._tag, 'absent')
+})
+
+test('follows a redirect to a public host and measures there', async () => {
+  const urls: string[] = []
+  let headCalls = 0
+  const outcome = await measureWith(async (url, init) => {
+    urls.push(String(url))
+    if (init?.method === 'HEAD') {
+      headCalls++
+      return headCalls === 1
+        ? new Response(null, { status: 302, headers: { location: 'https://example.org/real' } })
+        : new Response(null, { status: 200 })
+    }
+    return new Response(null, { status: 206, headers: { 'content-range': 'bytes 0-0/4321' } })
+  })
+
+  assert.equal(urls[1], 'https://example.org/real')
+  assert.ok(outcome._tag === 'measured')
+  assert.equal(outcome.size, 4321)
+})
 
 test('counts a resource that answers 404 to every probe as absent', async () => {
   const outcome = await measureWith(async () => new Response(null, { status: 404 }))

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -441,3 +441,41 @@ test('an unmeasured resource makes the run incomplete, an absent one does not', 
   // The same counts, but the third answered 404. That is a fact about the page.
   assert.equal(assessCompleteness(3, 3, 2, false).complete, true)
 })
+
+/**
+ * A total labelled complete has to account for everything the served HTML
+ * asks for, not only the tags the first pass happened to cover.
+ */
+
+test('reads the resources named by embedded content elements', () => {
+  const html = `
+    <iframe src="/frame.html"></iframe>
+    <embed src="/plugin.swf">
+    <object data="/thing.pdf"></object>
+    <video src="/clip.mp4" poster="/poster.jpg"><track src="/subs.vtt"></video>
+  `
+
+  const urls = extractResourceRefs(html, 'https://example.com/').map(ref => ref.url)
+
+  for (const path of ['/frame.html', '/plugin.swf', '/thing.pdf', '/clip.mp4', '/poster.jpg', '/subs.vtt'])
+    assert.ok(urls.includes(`https://example.com${path}`), `missing ${path}`)
+})
+
+test('reads a video poster as its own image resource', () => {
+  const refs = extractResourceRefs('<video src="/a.mp4" poster="/p.jpg"></video>', 'https://example.com/')
+
+  assert.equal(refs.find(ref => ref.url.endsWith('/p.jpg'))?.type, 'image')
+})
+
+test('reads an object through data rather than src', () => {
+  const refs = extractResourceRefs('<object data="/thing.pdf" src="/ignored.js"></object>', 'https://example.com/')
+
+  assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/thing.pdf'])
+})
+
+test('refuses a private host before any request is attempted', () => {
+  // The endpoint parses the submitted URL through this guard before it calls
+  // validateUrl, whose reachability probe would otherwise make the request.
+  for (const raw of ['http://127.0.0.1/', 'http://169.254.169.254/', 'http://10.0.0.1/'])
+    assert.equal(parsePublicHttpUrl(raw)._tag, 'err', raw)
+})

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -43,6 +43,17 @@ test('refuses an IPv6 host that embeds a blocked IPv4 address', () => {
   assert.equal(parsePublicHttpUrl('http://[::ffff:8.8.8.8]/')._tag, 'ok')
 })
 
+test('refuses a loopback host written with a trailing dot', () => {
+  // `localhost.` resolves to loopback exactly like `localhost`, and the URL
+  // parser hands the dot through, so the guard has to drop it before matching.
+  assert.equal(parsePublicHttpUrl('http://localhost./')._tag, 'err')
+
+  // The same rule drops a ref that a public page's HTML names.
+  const refs = extractResourceRefs('<img src="http://localhost./x">', 'https://example.com/')
+
+  assert.deepEqual(refs, [])
+})
+
 test('refuses a scheme that is not http', () => {
   for (const raw of ['file:///etc/passwd', 'data:text/html,hi', 'javascript:alert(1)'])
     assert.equal(parsePublicHttpUrl(raw)._tag, 'err', raw)
@@ -332,6 +343,49 @@ test('measures a body that stays under the byte cap', async () => {
   assert.ok(outcome._tag === 'measured')
   assert.equal(outcome.size, 3 * 1024 * 1024)
   assert.equal(outcome.contentType, 'text/plain')
+})
+
+test('counts a chunked download without holding a copy of the body', async () => {
+  const bodyBytes = 3 * 1024 * 1024
+  const chunk = new Uint8Array(1024 * 1024).fill(0x63)
+  let sent = 0
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= 3) {
+        controller.close()
+        return
+      }
+      sent++
+      controller.enqueue(chunk)
+    },
+  })
+
+  // The download only needs a length, and sixteen downloads run at once, so
+  // materializing the body, let alone copying it, holds a hostile page's bytes
+  // against the Worker's memory cap. The only allocation of exactly the body's
+  // size in this flow is that second copy.
+  const realUint8Array = globalThis.Uint8Array
+  const copies: number[] = []
+  class CountingUint8Array extends realUint8Array {
+    constructor(length: number) {
+      super(length)
+      if (length === bodyBytes)
+        copies.push(length)
+    }
+  }
+  globalThis.Uint8Array = CountingUint8Array as unknown as typeof Uint8Array
+
+  try {
+    const outcome = await measureWith(async () => new Response(stream, { headers: { 'content-type': 'text/plain' } }))
+
+    if (outcome._tag !== 'measured')
+      assert.fail('expected the chunked download to be measured')
+    assert.equal(outcome.size, bodyBytes)
+    assert.deepEqual(copies, [])
+  }
+  finally {
+    globalThis.Uint8Array = realUint8Array
+  }
 })
 
 /**

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -393,3 +393,51 @@ test('stops cleanly on an unterminated comment', () => {
 
   assert.deepEqual(refs.map(ref => ref.url), ['https://example.com/a.png'])
 })
+
+/**
+ * A response says something about the page. A rejected fetch says something
+ * about the network, and the two must not be confused: counting a connection
+ * reset as a definitive answer shrinks the total while still calling the run
+ * complete.
+ */
+
+const measureOptions = {
+  deadline: Date.now() + 10_000,
+  timeoutMs: 5000,
+  maxBodyBytes: 5_000_000,
+  userAgent: 'test',
+}
+
+test('leaves a resource unmeasured when the connection fails', async () => {
+  const outcome = await measureResource('https://example.com/a.js', {
+    ...measureOptions,
+    fetchLike: () => Promise.reject(Object.assign(new Error('connection reset'), { name: 'TypeError' })),
+  })
+
+  assert.equal(outcome._tag, 'unmeasured')
+})
+
+test('leaves a resource unmeasured when the request times out', async () => {
+  const outcome = await measureResource('https://example.com/a.js', {
+    ...measureOptions,
+    fetchLike: () => Promise.reject(Object.assign(new Error('timed out'), { name: 'TimeoutError' })),
+  })
+
+  assert.equal(outcome._tag, 'unmeasured')
+})
+
+test('calls a resource absent only when the server answers definitively', async () => {
+  const outcome = await measureResource('https://example.com/gone.js', {
+    ...measureOptions,
+    fetchLike: () => Promise.resolve(new Response('', { status: 404 })),
+  })
+
+  assert.equal(outcome._tag, 'absent')
+})
+
+test('an unmeasured resource makes the run incomplete, an absent one does not', () => {
+  // Three found, three tried, two sized: the third was a connection failure.
+  assert.equal(assessCompleteness(3, 3, 2, true).complete, false)
+  // The same counts, but the third answered 404. That is a fact about the page.
+  assert.equal(assessCompleteness(3, 3, 2, false).complete, true)
+})

--- a/tests/page-weight.test.ts
+++ b/tests/page-weight.test.ts
@@ -1,0 +1,137 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  classifyResource,
+  extractResourceRefs,
+  parsePublicHttpUrl,
+  summarizeWeight,
+} from '../shared/page-weight.ts'
+
+test('refuses a URL that points back inside a network', () => {
+  const blocked = [
+    'http://localhost/admin',
+    'http://127.0.0.1/',
+    'http://10.1.2.3/',
+    'http://192.168.0.1/',
+    'http://172.16.0.1/',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://[::1]/',
+  ]
+
+  for (const raw of blocked)
+    assert.equal(parsePublicHttpUrl(raw)._tag, 'err', raw)
+})
+
+test('refuses a scheme that is not http', () => {
+  for (const raw of ['file:///etc/passwd', 'data:text/html,hi', 'javascript:alert(1)'])
+    assert.equal(parsePublicHttpUrl(raw)._tag, 'err', raw)
+})
+
+test('accepts a public http URL', () => {
+  const parsed = parsePublicHttpUrl('https://example.com/a?b=1')
+
+  assert.equal(parsed._tag, 'ok')
+  assert.ok(parsed._tag === 'ok')
+  assert.equal(parsed.url.toString(), 'https://example.com/a?b=1')
+})
+
+test('resolves a relative URL against the page it came from', () => {
+  const parsed = parsePublicHttpUrl('/_nuxt/entry.js', 'https://example.com/blog/post')
+
+  assert.ok(parsed._tag === 'ok')
+  assert.equal(parsed.url.toString(), 'https://example.com/_nuxt/entry.js')
+})
+
+test('prefers the served content type over the URL extension', () => {
+  // A script served from a path with no extension, which an extension guess misses.
+  assert.equal(classifyResource('https://example.com/api/bundle', 'application/javascript'), 'script')
+  // A content type wins even when the extension says otherwise.
+  assert.equal(classifyResource('https://example.com/a.css', 'image/png'), 'image')
+  assert.equal(classifyResource('https://example.com/a.woff2'), 'font')
+  assert.equal(classifyResource('https://example.com/whatever'), 'other')
+})
+
+const PAGE = `
+<!doctype html>
+<html><head>
+  <link rel="stylesheet" href="/style.css">
+  <link rel="preload" as="font" href="/f.woff2">
+  <link rel="canonical" href="https://example.com/canonical">
+  <script src="/app.js"></script>
+  <script>console.log('inline')</script>
+</head><body>
+  <img src="/hero.png">
+  <img srcset="/wide.avif 2x, /narrow.avif 1x" src="/fallback.png">
+  <video src="/clip.mp4"></video>
+  <img src="http://127.0.0.1/private.png">
+  <script src="/app.js"></script>
+</body></html>
+`
+
+test('reads every subresource the served HTML asks for', () => {
+  const refs = extractResourceRefs(PAGE, 'https://example.com/')
+  const byUrl = new Map(refs.map(ref => [ref.url, ref.type]))
+
+  assert.equal(byUrl.get('https://example.com/style.css'), 'stylesheet')
+  assert.equal(byUrl.get('https://example.com/f.woff2'), 'font')
+  assert.equal(byUrl.get('https://example.com/app.js'), 'script')
+  assert.equal(byUrl.get('https://example.com/hero.png'), 'image')
+  assert.equal(byUrl.get('https://example.com/clip.mp4'), 'media')
+})
+
+test('takes the first srcset candidate, the way a plain reader would', () => {
+  const refs = extractResourceRefs(PAGE, 'https://example.com/')
+
+  assert.ok(refs.some(ref => ref.url === 'https://example.com/wide.avif'))
+  assert.ok(!refs.some(ref => ref.url === 'https://example.com/fallback.png'))
+})
+
+test('skips a link rel that fetches nothing for this page', () => {
+  const refs = extractResourceRefs(PAGE, 'https://example.com/')
+
+  assert.ok(!refs.some(ref => ref.url === 'https://example.com/canonical'))
+})
+
+test('drops a subresource pointing back inside a network', () => {
+  const refs = extractResourceRefs(PAGE, 'https://example.com/')
+
+  assert.ok(!refs.some(ref => ref.url.includes('127.0.0.1')))
+})
+
+test('counts a repeated URL once, the way a browser fetches it once', () => {
+  const refs = extractResourceRefs(PAGE, 'https://example.com/')
+
+  assert.equal(refs.filter(ref => ref.url === 'https://example.com/app.js').length, 1)
+})
+
+test('groups measured resources by type, largest group first', () => {
+  const summary = summarizeWeight([
+    { url: 'https://e.com/', type: 'document', size: 1000 },
+    { url: 'https://e.com/a.js', type: 'script', size: 5000 },
+    { url: 'https://e.com/b.js', type: 'script', size: 3000 },
+    { url: 'https://e.com/c.png', type: 'image', size: 2000 },
+  ])
+
+  assert.equal(summary.totalSize, 11_000)
+  assert.equal(summary.totalRequests, 4)
+  assert.deepEqual(summary.groups.map(group => group.type), ['script', 'image', 'document'])
+  assert.deepEqual(
+    summary.groups.find(group => group.type === 'script'),
+    { type: 'script', count: 2, size: 8000 },
+  )
+})
+
+test('ranks the largest resources and caps the list at ten', () => {
+  const entries = Array.from({ length: 15 }, (_, i) => ({
+    url: `https://e.com/${i}`,
+    type: 'script' as const,
+    size: i * 100,
+  }))
+
+  const summary = summarizeWeight(entries)
+
+  assert.equal(summary.largestResources.length, 10)
+  assert.equal(summary.largestResources[0]?.size, 1400)
+  assert.equal(summary.largestResources.at(-1)?.size, 500)
+})

--- a/tests/run-gate.test.ts
+++ b/tests/run-gate.test.ts
@@ -1,0 +1,28 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createRunGate } from '../shared/run-gate.ts'
+
+test('a current run accepts its own resolution', () => {
+  const gate = createRunGate()
+  const run = gate.begin()
+
+  assert.ok(gate.isCurrent(run))
+})
+
+test('a resolution from a superseded run is rejected', () => {
+  const gate = createRunGate()
+  const first = gate.begin()
+  gate.begin()
+
+  assert.ok(!gate.isCurrent(first))
+})
+
+test('the newest run stays current across several rejections', () => {
+  const gate = createRunGate()
+  gate.begin()
+  gate.begin()
+  const third = gate.begin()
+
+  assert.ok(gate.isCurrent(third))
+})


### PR DESCRIPTION
### 📚 Description

Closes #44.

The page size tool read every number from a PageSpeed Insights Lighthouse run, ~25s on a cache miss, and a visitor reported that as too slow. Page weight does not need Lighthouse; the bytes are on the wire.

This adds a fast pass that reads the page directly. Lighthouse still runs and still fills the panels only it can.

```
t=0.0s   request
t=1-8s   total weight, request count, resource breakdown   ← new, read from the wire
t=~25s   performance score, unused JS/CSS, compression ratio,
         third-party main-thread time, screenshot          ← Lighthouse, as before
```

Nothing the tool showed is lost.

### Measured

Real pages, wall clock, cold:

| Page | Before | After | Coverage |
| --- | --- | --- | --- |
| example.com | ~25s | **0.2s** | 1/1 |
| github.com | ~25s | **1.6s** | 121/121 |
| unlighthouse.dev | ~25s | **2.7s** | 64/64 |
| nuxt.com | ~25s | 8.1s | 14/121, partial |

Servers disagree about which cheap probe they answer. Cloudflare in front of this site answers HEAD with a length; nuxt.com answers HEAD with no length but serves ranges. Each resource tries HEAD, then a one-byte range, before downloading anything, which turns most resources into one small round trip. That change alone took github.com from 4.8s to 1.6s.

### ⚠️ Two things the response is deliberately careful about

**The sizes are uncompressed bytes.** Every cheap probe reports the identity length, and `fetch` decodes transparently, so the true compressed transfer size is not reachable this way. That is a larger number than Lighthouse's `transferSize`, so it is labelled `totalUncompressedSize` and shown as "Uncompressed weight", not merged into the existing transfer figure.

**A partial run shows no total.** nuxt.com exhausts the 8s budget with most of itself unread, and a headline that is short by half is worse than waiting. When `complete` is false the UI shows the breakdown plus "Measured 14 of 121 resources", and defers the weight to Lighthouse.

It also runs no JavaScript, so resources a script loads later are not counted. The UI says that too.

### 🔒 Security

Reading the page is now this site's own request rather than Google's, which changes the risk. Every URL, including the ones taken out of the fetched HTML that the page author controls, goes through one `parsePublicHttpUrl` guard that refuses non-public hosts (loopback, RFC1918, link-local, IPv6 equivalents) and non-http schemes. The existing `validateUrl` does not do this; it accepts literal IPs.

Bounded by construction: 120 resources, 16 concurrent, 5s per resource, 8s overall.

### ✅ Tests

`tests/page-weight.test.ts`, 12 tests on the pure core: the host guard, scheme guard, relative resolution, content-type over extension, srcset, dedupe, rel filtering, grouping and ranking. 138 across the suite. Typecheck clean.

The parsing and classification are pure and IO-free, so they are tested directly rather than through a fetch.

> 🤖 AI disclosure: opened by [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit). [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01KGE9ALMX1BSCaYcLt4GzyU