### PR TITLE
chore(ci): create the Sentry release before the source map upload

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -71,6 +71,19 @@ jobs:
           # then blamed live errors on code that was never deployed.
           SENTRY_RELEASE: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      # Nothing else creates the release. `@sentry/nuxt` never registers its
+      # build plugin here (see the upload step below), and `sourcemaps upload
+      # --release` only tags the artifact bundle. The finalize step after the
+      # deploy failed with "Release not found" on its first two runs (#76).
+      # Creating a release that already exists is a no-op.
+      - name: Create Sentry release
+        run: pnpm exec sentry-cli releases new "$SENTRY_RELEASE"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: harlan-zw
+          SENTRY_PROJECT: unlighthouse
+          SENTRY_RELEASE: ${{ github.event.workflow_run.head_sha || github.sha }}
+
       # `@sentry/nuxt` only registers its source map upload plugin when a
       # `sentry.client.config.*` file exists, and this app configures Sentry
       # through `@harlan-zw/nuxt-sentry` instead. Without this step the hidden


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Related to #74

### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

Both deploys since #76 landed (`beef385`, `ef00cb2`) failed at the new finalize step:

```
error: Release not found. Ensure that you configured the correct release, project, and organization.
```

The Worker still shipped each time. #76 assumed the build created the release, but nothing does. `@sentry/nuxt` never registers its build plugin here, and `sentry-cli sourcemaps upload --release` only tags the artifact bundle. One `releases new` step after the build fixes that. Creating a release that already exists is a no-op, so the step stays safe if something upstream starts creating it.

Deploy-only step, so CI cannot exercise it. The next deploy run is the proof.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012AMRtb4ywqcEMJGoZyTd5H