### PR TITLE
chore(deps): bump @harlan-zw/nuxt-sentry to 0.1.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: 0.1.2
       version: 0.1.2
     '@harlan-zw/nuxt-sentry':
-      specifier: 0.1.2
-      version: 0.1.2
+      specifier: 0.1.4
+      version: 0.1.4
     '@iconify-json/carbon':
       specifier: ^1.2.25
       version: 1.2.25
@@ -348,7 +348,7 @@ importers:
         version: 0.1.2(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260815.1)(@opentelemetry/api@1.9.1))(magic-string@1.2.0)(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(oxc-parser@0.143.0)(rolldown@1.2.4)(srvx@0.12.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       '@harlan-zw/nuxt-sentry':
         specifier: 'catalog:'
-        version: 0.1.2(@sentry/cloudflare@10.70.0(@cloudflare/workers-types@5.20260815.1)(supports-color@10.2.2)(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1)))(@sentry/nuxt@10.70.0(@cloudflare/workers-types@5.20260815.1)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(rollup@4.62.4)(supports-color@10.2.2)(vue@3.5.41(typescript@6.0.3))(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1)))(magic-string@1.2.0)(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+        version: 0.1.4(@sentry/cloudflare@10.70.0(@cloudflare/workers-types@5.20260815.1)(supports-color@10.2.2)(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1)))(@sentry/nuxt@10.70.0(@cloudflare/workers-types@5.20260815.1)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(rollup@4.62.4)(supports-color@10.2.2)(vue@3.5.41(typescript@6.0.3))(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1)))(magic-string@1.2.0)(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@iconify-json/carbon':
         specifier: 'catalog:'
         version: 1.2.25
@@ -1444,13 +1444,13 @@ packages:
     peerDependencies:
       nuxt: '>=4.5.0 <5.0.0'
 
-  '@harlan-zw/nuxt-sentry@0.1.2':
-    resolution: {integrity: sha512-hTUEQT2TTs7lK+xqByrssKm6LAArdOFY1jV19mGgLWKLSq1eDr8Yltsjav82Aph4UwilEqMYAQrBwOmnblDsgg==}
+  '@harlan-zw/nuxt-sentry@0.1.4':
+    resolution: {integrity: sha512-uEBHa8PlXWRGYwJ0reln2h4nbAX2HxsfxFzKN+NUzoQZQ/Btl89Uj1rJGGH0fv0BnMPr8iZjeVHEYpjvSJ6zSg==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@sentry/cloudflare': ^10.70.0
       '@sentry/nuxt': ^10.70.0
-      nuxt: '>=4.5.0 <5.0.0'
+      nuxt: '>=4.5.0 <6.0.0'
     peerDependenciesMeta:
       '@sentry/cloudflare':
         optional: true
@@ -10107,7 +10107,7 @@ snapshots:
       - webpack
       - xml2js
 
-  '@harlan-zw/nuxt-sentry@0.1.2(@sentry/cloudflare@10.70.0(@cloudflare/workers-types@5.20260815.1)(supports-color@10.2.2)(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1)))(@sentry/nuxt@10.70.0(@cloudflare/workers-types@5.20260815.1)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(rollup@4.62.4)(supports-color@10.2.2)(vue@3.5.41(typescript@6.0.3))(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1)))(magic-string@1.2.0)(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))':
+  '@harlan-zw/nuxt-sentry@0.1.4(@sentry/cloudflare@10.70.0(@cloudflare/workers-types@5.20260815.1)(supports-color@10.2.2)(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1)))(@sentry/nuxt@10.70.0(@cloudflare/workers-types@5.20260815.1)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(rollup@4.62.4)(supports-color@10.2.2)(vue@3.5.41(typescript@6.0.3))(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1)))(magic-string@1.2.0)(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@sentry/nuxt': 10.70.0(@cloudflare/workers-types@5.20260815.1)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(magicast@0.5.4)(nuxt@4.5.2(fd132a1268f7946e87bb29bba31c20de))(rollup@4.62.4)(supports-color@10.2.2)(vue@3.5.41(typescript@6.0.3))(wrangler@4.123.0(@cloudflare/workers-types@5.20260815.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ minimumReleaseAgeExclude:
   - '@comark/vue'
   - comark
   - '@harlan-zw/nuxt-dx@0.1.1'
-  - '@harlan-zw/nuxt-sentry@0.1.2'
+  - '@harlan-zw/nuxt-sentry@0.1.4'
   - '@harlan-zw/nuxt-github-sponsors@0.1.2'
   - '@types/three@0.185.0'
   - nuxt-ai-ready@1.7.9
@@ -40,7 +40,7 @@ catalog:
   '@harlan-zw/nuxt-cloudflare': 0.1.0
   '@harlan-zw/nuxt-dx': 0.1.1
   '@harlan-zw/nuxt-github-sponsors': 0.1.2
-  '@harlan-zw/nuxt-sentry': 0.1.2
+  '@harlan-zw/nuxt-sentry': 0.1.4
   '@iconify-json/carbon': ^1.2.25
   '@iconify-json/catppuccin': ^1.2.17
   '@iconify-json/heroicons': ^1.2.3


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #25

### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

The `ai-ready:cron` task is registered by nuxt-ai-ready from inside its own package, so nothing here could wrap it, and its throws only ever surfaced as Cloudflare `scriptThrewException`, about 150 a day since 2026-08-13. nuxt-sentry 0.1.4 (harlan-zw/harlan-nuxt#130) wraps every registered Nitro task at build time, so this bump is the whole fix. `rate-limits:cleanup` gets the same treatment.

No site code changes. Proof is the next cron failure landing in Sentry tagged `task:ai-ready:cron` instead of the Cloudflare exception counter.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012AMRtb4ywqcEMJGoZyTd5H