### PR TITLE
feat(admin): let an admin resolve a feedback comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ lighthouse
 
 # Daily check-in archives hold user feedback text; this repo is public
 docs/ops/checkins/
+
+# PR Lens writes its previews here. They are rebuilt on demand.
+.pr-lens/

--- a/layers/admin/app/pages/admin/index.vue
+++ b/layers/admin/app/pages/admin/index.vue
@@ -225,6 +225,7 @@ interface FeedbackEntry {
   userId: string | null
   sessionId: string | null
   createdAt: number | string | Date
+  resolvedAt: number | string | Date | null
 }
 
 interface FeedbackResponse {
@@ -232,6 +233,7 @@ interface FeedbackResponse {
   stats: { up: number, down: number }
   byPath: Record<string, number>
   commentCount: number
+  openCommentCount: number
   total: number
   thumbsByTool: { path: string, up: number, down: number, total: number }[]
 }
@@ -257,9 +259,33 @@ const filteredFeedback = computed(() => {
   return feedbackData.value.entries.filter(e => e.path === activeFeedbackPath.value)
 })
 
+// Open comments first. Each one still waits for a decision; a resolved one is history.
 const feedbackComments = computed(() =>
-  filteredFeedback.value.filter(e => e.comment),
+  filteredFeedback.value
+    .filter(e => e.comment)
+    .toSorted((a, b) => Number(a.resolvedAt !== null) - Number(b.resolvedAt !== null)),
 )
+
+const openFeedbackComments = computed(() => feedbackComments.value.filter(e => e.resolvedAt === null))
+
+const resolvingFeedbackIds = ref(new Set<string>())
+const toast = useToast()
+
+async function setFeedbackResolution(entry: FeedbackEntry, resolved: boolean) {
+  resolvingFeedbackIds.value.add(entry.id)
+  const result = await $fetch<{ id: string, resolvedAt: number | null }>(`/api/admin/feedback/${entry.id}`, {
+    method: 'PATCH',
+    body: { resolved },
+  }).catch((error: { statusCode?: number, message?: string }) => {
+    toast.add({ title: `Could not ${resolved ? 'resolve' : 'reopen'} the comment`, description: error.message, color: 'error' })
+    return null
+  })
+  resolvingFeedbackIds.value.delete(entry.id)
+  if (!result || !feedbackData.value)
+    return
+  entry.resolvedAt = result.resolvedAt
+  feedbackData.value.openCommentCount += resolved ? -1 : 1
+}
 
 function getFeedbackMetadata(entry: FeedbackEntry) {
   if (!entry.metadata)
@@ -1019,13 +1045,14 @@ function toggleJourney(id: string) {
           <!-- Comments -->
           <div v-if="feedbackComments.length" class="space-y-3 mb-6">
             <h3 class="text-sm font-medium text-muted uppercase tracking-wider">
-              Comments ({{ feedbackComments.length }})
+              Comments ({{ openFeedbackComments.length }} open of {{ feedbackComments.length }})
             </h3>
             <div class="grid gap-3">
               <div
                 v-for="entry in feedbackComments"
                 :key="entry.id"
-                class="p-4 rounded-xl bg-elevated border border-default"
+                class="p-4 rounded-xl bg-elevated border border-default transition-opacity"
+                :class="entry.resolvedAt !== null ? 'opacity-60' : ''"
               >
                 <div class="flex items-start gap-3">
                   <div
@@ -1066,6 +1093,18 @@ function toggleJourney(id: string) {
                       >
                         {{ formatRelativeTime(new Date(typeof entry.createdAt === 'number' ? entry.createdAt * 1000 : entry.createdAt)) }}
                       </time>
+                      <UBadge v-if="entry.resolvedAt !== null" color="success" variant="subtle" size="xs">
+                        Resolved
+                      </UBadge>
+                      <UButton
+                        size="xs"
+                        variant="ghost"
+                        :color="entry.resolvedAt !== null ? 'neutral' : 'success'"
+                        :icon="entry.resolvedAt !== null ? 'i-carbon-renew' : 'i-carbon-checkmark'"
+                        :loading="resolvingFeedbackIds.has(entry.id)"
+                        :label="entry.resolvedAt !== null ? 'Reopen' : 'Resolve'"
+                        @click="setFeedbackResolution(entry, entry.resolvedAt === null)"
+                      />
                     </div>
                   </div>
                 </div>

--- a/layers/admin/server/api/admin/feedback.get.ts
+++ b/layers/admin/server/api/admin/feedback.get.ts
@@ -7,7 +7,7 @@ export default defineEventHandler(async (event) => {
   await requireAdminAuth(event)
   const db = getDB(event)
 
-  const [entries, thumbStats, pathStats, thumbsByToolRaw, commentStats] = await Promise.all([
+  const [entries, thumbStats, pathStats, thumbsByToolRaw, commentStats, openCommentStats] = await Promise.all([
     db.select().from(feedback).orderBy(desc(feedback.createdAt)).limit(100),
     db.select({
       thumb: feedback.thumb,
@@ -25,6 +25,9 @@ export default defineEventHandler(async (event) => {
     db.select({ count: sql<number>`count(*)`.as('count') })
       .from(feedback)
       .where(sql`${feedback.comment} IS NOT NULL AND trim(${feedback.comment}) != ''`),
+    db.select({ count: sql<number>`count(*)`.as('count') })
+      .from(feedback)
+      .where(sql`${feedback.comment} IS NOT NULL AND trim(${feedback.comment}) != '' AND ${feedback.resolvedAt} IS NULL`),
   ])
 
   const stats = { up: 0, down: 0 }
@@ -34,6 +37,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const commentCount = commentStats[0]?.count ?? 0
+  const openCommentCount = openCommentStats[0]?.count ?? 0
   const byPath = Object.fromEntries(pathStats.map(s => [s.path, s.count])) as Record<string, number>
 
   // Aggregate thumbs by tool into { path, up, down, total }[]
@@ -59,6 +63,7 @@ export default defineEventHandler(async (event) => {
     stats,
     byPath,
     commentCount,
+    openCommentCount,
     total: stats.up + stats.down + commentCount,
     thumbsByTool,
   }

--- a/layers/admin/server/api/admin/feedback/[id].patch.ts
+++ b/layers/admin/server/api/admin/feedback/[id].patch.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+import { getD1 } from '../../../../../../server/utils/db'
+import { setFeedbackResolution } from '../../../../../../server/utils/feedback-resolution'
+import { requireAdminAuth } from '../../../utils/admin'
+
+const ParamsSchema = z.object({ id: z.string().min(1).max(100) })
+const BodySchema = z.object({ resolved: z.boolean() })
+
+/** Marks one feedback comment resolved or reopens it. */
+export default defineEventHandler(async (event) => {
+  await requireAdminAuth(event)
+  const { id } = await getValidatedRouterParams(event, ParamsSchema.parse)
+  const { resolved } = await readValidatedBody(event, BodySchema.parse)
+
+  const d1 = getD1(event)
+  if (!d1)
+    throw createError({ statusCode: 500, message: 'Database not available' })
+
+  const result = await setFeedbackResolution(d1, { id, resolved })
+  if (result._tag === 'Err')
+    throw createError({ statusCode: 404, message: 'Feedback not found' })
+
+  return { id: result.id, resolvedAt: result.resolvedAt }
+})

--- a/scripts/tools/daily-checkin-data.mjs
+++ b/scripts/tools/daily-checkin-data.mjs
@@ -181,7 +181,9 @@ const d1 = probe(() => {
     // Every feedback row since the last run, in full. This is the work list the
     // check-in exists to produce, so it is never summarised away.
     feedbackSinceLastRun: d1Query(`SELECT id, path, thumb, comment, created_at, user_id IS NOT NULL AS has_user, substr(COALESCE(metadata, ''), 1, 400) metadata FROM feedback WHERE created_at >= ${sinceSec} ORDER BY created_at DESC LIMIT 50`),
-    feedbackOpenComments: d1Query(`SELECT id, path, comment, created_at FROM feedback WHERE comment IS NOT NULL AND comment != '' ORDER BY created_at DESC LIMIT 20`),
+    // Resolved in the admin view means an action was taken, so only NULL rows
+    // are still an unanswered user.
+    feedbackOpenComments: d1Query(`SELECT id, path, comment, created_at FROM feedback WHERE comment IS NOT NULL AND comment != '' AND resolved_at IS NULL ORDER BY created_at DESC LIMIT 20`),
     feedbackTotals: d1Query(`SELECT
       COUNT(*) total,
       COALESCE(SUM(created_at >= ${day}), 0) total_24h,

--- a/server/database/migrations/0005_feedback_resolved_at.sql
+++ b/server/database/migrations/0005_feedback_resolved_at.sql
@@ -1,0 +1,6 @@
+-- A feedback comment is open until an admin resolves it.
+--
+-- Before this column the admin view was read-only, so "answered" had no
+-- representation and the daily check-in re-flagged the same comments every
+-- run. `resolved_at` is the admin's decision as a unix timestamp; NULL is open.
+ALTER TABLE feedback ADD COLUMN resolved_at INTEGER;

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -39,6 +39,8 @@ export const feedback = sqliteTable('feedback', {
   userId: text('user_id').references(() => users.id, { onDelete: 'set null' }),
   sessionId: text('session_id'),
   createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+  /** The admin's close decision. NULL means the comment still waits for one. */
+  resolvedAt: integer('resolved_at', { mode: 'timestamp' }),
 }, t => [
   index('feedback_session_id_idx').on(t.sessionId),
 ])

--- a/server/utils/feedback-resolution.ts
+++ b/server/utils/feedback-resolution.ts
@@ -1,0 +1,38 @@
+/** The slice of D1 this store uses, so a test can supply a database of its own. */
+export interface FeedbackResolutionDatabase {
+  prepare: (sql: string) => {
+    bind: (...values: unknown[]) => {
+      run: () => Promise<{ meta: { changes: number } }>
+    }
+  }
+}
+
+export interface FeedbackResolutionInput {
+  id: string
+  resolved: boolean
+}
+
+export type FeedbackResolutionResult
+  = | { _tag: 'Ok', id: string, resolvedAt: number | null }
+    | { _tag: 'Err', reason: 'not-found' }
+
+const SET_RESOLUTION_SQL = 'UPDATE feedback SET resolved_at = ?1 WHERE id = ?2'
+
+/**
+ * Records the admin's close decision on one feedback row.
+ *
+ * `resolved: true` stamps the row with the clock, `false` reopens it. The row
+ * count from the UPDATE is the existence check, so a stale id from the admin
+ * view is an error value instead of a silent no-op.
+ */
+export async function setFeedbackResolution(
+  db: FeedbackResolutionDatabase,
+  { id, resolved }: FeedbackResolutionInput,
+  now: () => number = () => Math.floor(Date.now() / 1000),
+): Promise<FeedbackResolutionResult> {
+  const resolvedAt = resolved ? now() : null
+  const { meta } = await db.prepare(SET_RESOLUTION_SQL).bind(resolvedAt, id).run()
+  if (meta.changes === 0)
+    return { _tag: 'Err', reason: 'not-found' }
+  return { _tag: 'Ok', id, resolvedAt }
+}

--- a/tests/feedback-resolution.test.ts
+++ b/tests/feedback-resolution.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable test/no-import-node-test */
+import type { FeedbackResolutionDatabase } from '../server/utils/feedback-resolution.ts'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { setFeedbackResolution } from '../server/utils/feedback-resolution.ts'
+
+const migrations = ['0001_initial.sql', '0005_feedback_resolved_at.sql'].map(file => readFileSync(
+  fileURLToPath(new URL(`../server/database/migrations/${file}`, import.meta.url)),
+  'utf8',
+))
+
+/**
+ * Real SQLite, the engine D1 runs, so the UPDATE and its change count behave
+ * the way production reports them.
+ */
+function sqliteDatabase(): FeedbackResolutionDatabase & { close: () => void, resolvedAt: (id: string) => number | null } {
+  const db = new DatabaseSync(':memory:')
+  for (const migration of migrations)
+    db.exec(migration)
+  db.prepare(`INSERT INTO feedback (id, path, comment, created_at) VALUES ('fb-1', '/api-doc', 'doc is incomplete', 100)`).run()
+  return {
+    prepare: sql => ({
+      bind: (...values) => ({
+        run: async () => {
+          await Promise.resolve()
+          const { changes } = db.prepare(sql).run(...values as never[]) as { changes: number }
+          return { meta: { changes } }
+        },
+      }),
+    }),
+    resolvedAt: id => (db.prepare('SELECT resolved_at AS at FROM feedback WHERE id = ?').get(id) as { at: number | null }).at,
+    close: () => db.close(),
+  }
+}
+
+test('resolving stamps the comment with the clock', async () => {
+  const db = sqliteDatabase()
+  try {
+    const result = await setFeedbackResolution(db, { id: 'fb-1', resolved: true }, () => 5000)
+    assert.deepEqual(result, { _tag: 'Ok', id: 'fb-1', resolvedAt: 5000 })
+    assert.equal(db.resolvedAt('fb-1'), 5000)
+  }
+  finally {
+    db.close()
+  }
+})
+
+test('reopening clears the stamp', async () => {
+  const db = sqliteDatabase()
+  try {
+    await setFeedbackResolution(db, { id: 'fb-1', resolved: true }, () => 5000)
+    const result = await setFeedbackResolution(db, { id: 'fb-1', resolved: false }, () => 6000)
+    assert.deepEqual(result, { _tag: 'Ok', id: 'fb-1', resolvedAt: null })
+    assert.equal(db.resolvedAt('fb-1'), null)
+  }
+  finally {
+    db.close()
+  }
+})
+
+test('an unknown id is an error value, not a silent no-op', async () => {
+  const db = sqliteDatabase()
+  try {
+    const result = await setFeedbackResolution(db, { id: 'missing', resolved: true }, () => 5000)
+    assert.deepEqual(result, { _tag: 'Err', reason: 'not-found' })
+    assert.equal(db.resolvedAt('fb-1'), null)
+  }
+  finally {
+    db.close()
+  }
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #83

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 👌 Enhancement (improving an existing functionality)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

The admin feedback view was read-only, so a comment that got an answer looked the same as one nobody read. The daily check-in kept re-flagging the same four comments and opened #83 about them.

A `resolved_at` column on `feedback` records the decision. Each comment card on `/admin` gets a Resolve or Reopen button behind a new admin-only PATCH route, and the check-in query filters on the column, so a resolved comment stops counting as an unanswered user.

![Architecture: the admin page writes resolved_at through the new PATCH route; the admin counts and the daily check-in read it](https://github.com/user-attachments/assets/2cdc8c3a-5779-4418-b038-96a51bb0fc62)

Migration 0005 is one `ALTER TABLE ... ADD COLUMN`, applied by the deploy workflow before the Worker ships. Nothing reads the column until then.

Not done here: the four comments in #83 still need their decisions. Once this deploys I'll resolve the three noise ones from the admin page. The `puppeteer:before-goto` one waits on the v1 docs landing.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012AMRtb4ywqcEMJGoZyTd5H
